### PR TITLE
add missing alias Data.NPCItem

### DIFF
--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -6,6 +6,7 @@ alias Data.Exit
 alias Data.HelpTopic
 alias Data.Item
 alias Data.NPC
+alias Data.NPCItem
 alias Data.NPCSpawner
 alias Data.Race
 alias Data.Room


### PR DESCRIPTION
`mix run priv/repo/seeds.exs` would fail because this alias was missing.