### PR TITLE
Send a "character/died" notification

### DIFF
--- a/lib/game/character.ex
+++ b/lib/game/character.ex
@@ -6,7 +6,6 @@ defmodule Game.Character do
   handle the following casts:
 
   - `{:targeted, player}`
-  - `{:remove_target, player}`
   - `{:apply_effects, effects, player}`
   """
 
@@ -30,14 +29,6 @@ defmodule Game.Character do
   @spec being_targeted(tuple(), Character.t()) :: :ok
   def being_targeted(target, player) do
     GenServer.cast({:via, Via, who(target)}, {:targeted, player})
-  end
-
-  @doc """
-  When a player stops targetting a character, let them know
-  """
-  @spec remove_target(tuple(), Character.t()) :: :ok
-  def remove_target(target, player) do
-    GenServer.cast({:via, Via, who(target)}, {:remove_target, player})
   end
 
   @doc """

--- a/lib/game/character.ex
+++ b/lib/game/character.ex
@@ -8,7 +8,6 @@ defmodule Game.Character do
   - `{:targeted, player}`
   - `{:remove_target, player}`
   - `{:apply_effects, effects, player}`
-  - `{:died, player}`
   """
 
   alias Data.NPC
@@ -47,16 +46,6 @@ defmodule Game.Character do
   @spec apply_effects(tuple(), [Effect.t()], Character.t(), String.t()) :: :ok
   def apply_effects(target, effects, from, description) do
     GenServer.cast({:via, Via, who(target)}, {:apply_effects, effects, from, description})
-  end
-
-  @doc """
-  Let the character targeting you know you died
-
-  PC targets NPC, NPC dies, NPC let's the PC know it died. Should clear the target on the PC.
-  """
-  @spec died(Character.t(), Character.t()) :: :ok
-  def died(target, who) do
-    GenServer.cast({:via, Via, who(target)}, {:died, who})
   end
 
   @doc """

--- a/lib/game/character/helpers.ex
+++ b/lib/game/character/helpers.ex
@@ -18,15 +18,15 @@ defmodule Game.Character.Helpers do
   @doc """
   Update the effect count. If the effect count is 0, remove it from the states continuous effects list
   """
-  @spec update_effect_count(map(), Effect.t()) :: map()
-  def update_effect_count(state, effect) do
-    continuous_effects = List.delete(state.continuous_effects, effect)
+  @spec update_effect_count(map(), {Character.t(), Effect.t()}) :: map()
+  def update_effect_count(state, {from, effect}) do
+    continuous_effects = List.delete(state.continuous_effects, {from, effect})
     effect = %{effect | count: effect.count - 1}
     maybe_send_continuous_effect(effect)
 
     case effect.count do
       0 -> %{state | continuous_effects: continuous_effects}
-      _ -> %{state | continuous_effects: [effect | continuous_effects]}
+      _ -> %{state | continuous_effects: [{from, effect} | continuous_effects]}
     end
   end
 

--- a/lib/game/character/helpers.ex
+++ b/lib/game/character/helpers.ex
@@ -5,26 +5,7 @@ defmodule Game.Character.Helpers do
 
   use Game.Room
 
-  alias Game.Character
-  alias Game.Session
-  alias Game.Session.GMCP
-
-  @doc """
-  If the state has a target, send the target a removal message.
-  """
-  @spec clear_target(Session.t(), Character.t()) :: :ok
-  def clear_target(state, who)
-
-  def clear_target(%{target: target}, who = {:npc, _}) when target != nil do
-    Character.remove_target(target, who)
-  end
-
-  def clear_target(state = %{target: target}, who) when target != nil do
-    state |> GMCP.clear_target()
-    Character.remove_target(target, who)
-  end
-
-  def clear_target(_state, _who), do: :ok
+  alias Data.Effect
 
   @doc """
   Update a character's stats in the room

--- a/lib/game/command/move.ex
+++ b/lib/game/command/move.ex
@@ -228,6 +228,7 @@ defmodule Game.Command.Move do
       state
       |> Map.put(:save, save)
       |> Map.put(:target, nil)
+      |> Map.put(:is_targeting, MapSet.new())
 
     @room.enter(room_id, {:user, user}, enter_reason)
 

--- a/lib/game/command/move.ex
+++ b/lib/game/command/move.ex
@@ -10,8 +10,6 @@ defmodule Game.Command.Move do
   alias Game.Door
   alias Game.Session.GMCP
 
-  import Game.Character.Helpers, only: [clear_target: 2]
-
   @must_be_alive true
 
   commands(
@@ -220,7 +218,7 @@ defmodule Game.Command.Move do
   def move_to(state = %{save: save, user: user}, room_id, leave_reason \\ :leave, enter_reason \\ :enter) do
     @room.leave(save.room_id, {:user, user}, leave_reason)
 
-    clear_target(state, {:user, user})
+    clear_target(state)
 
     save = %{save | room_id: room_id}
 
@@ -277,4 +275,16 @@ defmodule Game.Command.Move do
     state |> GMCP.map(mini_map)
     :ok
   end
+
+  @doc """
+  If the state has a target, send a GMCP message that the target was cleared
+  """
+  @spec clear_target(Session.t()) :: :ok
+  def clear_target(state)
+
+  def clear_target(state = %{target: target}) when target != nil do
+    state |> GMCP.clear_target()
+  end
+
+  def clear_target(_state), do: :ok
 end

--- a/lib/game/effect.ex
+++ b/lib/game/effect.ex
@@ -207,10 +207,13 @@ defmodule Game.Effect do
 
   - `damage/over-time`
   """
-  @spec continuous_effects([Effect.t()]) :: [Effect.t()]
-  def continuous_effects(effects) do
+  @spec continuous_effects([Effect.t()], Character.t()) :: [Effect.t()]
+  def continuous_effects(effects, from) do
     effects
     |> Enum.filter(&Effect.continuous?/1)
     |> Enum.map(&Effect.instantiate/1)
+    |> Enum.map(fn effect ->
+      {from, effect}
+    end)
   end
 end

--- a/lib/game/npc.ex
+++ b/lib/game/npc.ex
@@ -238,10 +238,6 @@ defmodule Game.NPC do
     {:noreply, state}
   end
 
-  def handle_cast({:remove_target, _player}, state) do
-    {:noreply, state}
-  end
-
   def handle_cast({:apply_effects, effects, from, _description}, state = %{npc: npc}) do
     Logger.info(
       "Applying effects to NPC (#{npc.id}) from (#{elem(from, 0)}, #{elem(from, 1).id})",

--- a/lib/game/npc.ex
+++ b/lib/game/npc.ex
@@ -261,10 +261,6 @@ defmodule Game.NPC do
     {:noreply, state}
   end
 
-  def handle_cast({:died, _who}, state = %{target: nil}) do
-    {:noreply, state}
-  end
-
   def handle_cast({:died, who}, state = %{target: target, npc: npc}) do
     case Character.who(target) == Character.who(who) do
       true ->
@@ -276,8 +272,7 @@ defmodule Game.NPC do
     end
   end
 
-  def handle_cast(:terminate, state = %{room_id: room_id, npc: npc, is_targeting: is_targeting}) do
-    Enum.each(is_targeting, &Character.died(&1, {:npc, npc}))
+  def handle_cast(:terminate, state = %{room_id: room_id, npc: npc}) do
     room_id |> @room.leave({:npc, npc})
     {:stop, :normal, state}
   end

--- a/lib/game/npc/events.ex
+++ b/lib/game/npc/events.ex
@@ -191,10 +191,6 @@ defmodule Game.NPC.Events do
   @spec act_on_room_entered(NPC.State.t(), Character.t(), Event.t()) :: NPC.State.t()
   def act_on_room_entered(state, character, event)
 
-  def act_on_room_entered(state, {:user, _, user}, event) do
-    act_on_room_entered(state, {:user, user}, event)
-  end
-
   def act_on_room_entered(state, {:user, _}, %{action: %{type: "say", message: message}}) do
     %{room_id: room_id, npc: npc} = state
     room_id |> @room.say({:npc, npc}, Message.npc(npc, message))

--- a/lib/game/npc/events.ex
+++ b/lib/game/npc/events.ex
@@ -73,6 +73,11 @@ defmodule Game.NPC.Events do
   @spec act_on(NPC.State.t(), {String.t(), any()}) :: :ok | {:update, NPC.State.t()}
   def act_on(state, action)
 
+  def act_on(state = %{npc: npc}, {"character/died", character, :character, from}) do
+    broadcast(npc, "character/died", who(character))
+    state |> act_on_character_died(character, from)
+  end
+
   def act_on(state = %{npc: npc}, {"combat/tick"}) do
     broadcast(npc, "combat/tick")
     state |> act_on_combat_tick()
@@ -128,6 +133,22 @@ defmodule Game.NPC.Events do
   end
 
   def act_on(_, _), do: :ok
+
+  @doc """
+  Act on a character death notification
+
+  Clear the target if the target matches
+  """
+  def act_on_character_died(%{target: nil}, _character, _from), do: :ok
+
+  def act_on_character_died(state, character, _from) do
+    case Character.who(character) == Character.who(state.target) do
+      true ->
+        {:update, Map.put(state, :target, nil)}
+      false ->
+        :ok
+    end
+  end
 
   @doc """
   Act on a combat tick, if the NPC has a target, pick an event and apply those effects

--- a/lib/game/session/character.ex
+++ b/lib/game/session/character.ex
@@ -26,14 +26,6 @@ defmodule Game.Session.Character do
   end
 
   @doc """
-  Callback for someone stopping targeting you
-  """
-  def remove_target(state, character) do
-    Session.echo(self(), "You are no longer being targeted by #{Format.name(character)}.")
-    Map.put(state, :is_targeting, MapSet.delete(state.is_targeting, Character.who(character)))
-  end
-
-  @doc """
   Callback for applying effects
   """
   def apply_effects(state, effects, from, description) do

--- a/lib/game/session/effects.ex
+++ b/lib/game/session/effects.ex
@@ -32,7 +32,7 @@ defmodule Game.Session.Effects do
     state = %{state | user: user, save: save}
 
     user |> echo_effects(from, description, effects)
-    user |> maybe_died(state)
+    user |> maybe_died(state, from)
 
     Enum.each(continuous_effects, fn effect ->
       :erlang.send_after(effect.every, self(), {:continuous_effect, effect.id})
@@ -50,16 +50,16 @@ defmodule Game.Session.Effects do
   @doc """
   Check for health < 0 and perform actions if it is
   """
-  @spec maybe_died(User.t(), State.t()) :: :ok
-  def maybe_died(user, state)
+  @spec maybe_died(User.t(), State.t(), Character.t()) :: :ok
+  def maybe_died(user, state, from)
 
-  def maybe_died(user = %{save: %{stats: %{health: health}}}, state) when health < 1 do
+  def maybe_died(user = %{save: %{stats: %{health: health}}}, state, from) when health < 1 do
     user |> maybe_transport_to_graveyard()
-    user |> notify_targeters(state.is_targeting)
+    state.save.room_id |> @room.notify({:user, user}, {"character/died", {:user, user}, :character, from})
     :ok
   end
 
-  def maybe_died(_user, _state), do: :ok
+  def maybe_died(_user, _state, _from), do: :ok
 
   @doc """
   Check if there is a graveyard to teleport to. The zone will have it set
@@ -77,14 +77,6 @@ defmodule Game.Session.Effects do
       {:error, :no_graveyard} ->
         :ok
     end
-  end
-
-  @doc """
-  Notify targets of death
-  """
-  @spec notify_targeters(User.t(), []) :: :ok
-  def notify_targeters(user, is_targeting) do
-    Enum.each(is_targeting, &Character.died(&1, {:user, user}))
   end
 
   @doc """
@@ -129,7 +121,7 @@ defmodule Game.Session.Effects do
 
     socket |> @socket.echo([effect] |> Format.effects() |> Enum.join("\n"))
 
-    user |> maybe_died(state)
+    user |> maybe_died(state, {:user, user})
 
     case is_alive?(save) do
       true ->

--- a/lib/game/session/effects.ex
+++ b/lib/game/session/effects.ex
@@ -23,7 +23,7 @@ defmodule Game.Session.Effects do
   def apply(effects, from, description, state) do
     %{user: user, save: save} = state
 
-    continuous_effects = effects |> Effect.continuous_effects()
+    continuous_effects = effects |> Effect.continuous_effects(from)
     stats = effects |> Effect.apply(save.stats)
 
     save = Map.put(save, :stats, stats)
@@ -34,7 +34,7 @@ defmodule Game.Session.Effects do
     user |> echo_effects(from, description, effects)
     user |> maybe_died(state, from)
 
-    Enum.each(continuous_effects, fn effect ->
+    Enum.each(continuous_effects, fn {_from, effect} ->
       :erlang.send_after(effect.every, self(), {:continuous_effect, effect.id})
     end)
 
@@ -100,7 +100,7 @@ defmodule Game.Session.Effects do
   """
   @spec handle_continuous_effect(State.t(), String.t()) :: State.t()
   def handle_continuous_effect(state, effect_id) do
-    case Enum.find(state.continuous_effects, &(&1.id == effect_id)) do
+    case Enum.find(state.continuous_effects, fn {_from, effect} -> effect.id == effect_id end) do
       nil -> state
       effect -> apply_continuous_effect(state, effect)
     end
@@ -110,7 +110,7 @@ defmodule Game.Session.Effects do
   Apply a continuous effect to the user
   """
   @spec apply_continuous_effect(State.t(), Effect.t()) :: State.t()
-  def apply_continuous_effect(state, effect) do
+  def apply_continuous_effect(state, {from, effect}) do
     %{socket: socket, user: user, save: save} = state
 
     stats = [effect] |> Effect.apply(save.stats)
@@ -121,11 +121,11 @@ defmodule Game.Session.Effects do
 
     socket |> @socket.echo([effect] |> Format.effects() |> Enum.join("\n"))
 
-    user |> maybe_died(state, {:user, user})
+    user |> maybe_died(state, from)
 
     case is_alive?(save) do
       true ->
-        state |> update_effect_count(effect)
+        state |> update_effect_count({from, effect})
 
       false ->
         state |> Map.put(:continuous_effects, [])

--- a/lib/game/session/process.ex
+++ b/lib/game/session/process.ex
@@ -186,10 +186,6 @@ defmodule Game.Session.Process do
     {:noreply, SessionCharacter.notify(state, event)}
   end
 
-  def handle_cast({:died, who}, state = %{state: "active"}) do
-    {:noreply, SessionCharacter.died(state, who)}
-  end
-
   def handle_call(:info, _from, state) do
     {:reply, {:user, state.user}, state}
   end

--- a/lib/game/session/process.ex
+++ b/lib/game/session/process.ex
@@ -11,8 +11,6 @@ defmodule Game.Session.Process do
 
   require Logger
 
-  import Game.Character.Helpers, only: [clear_target: 2]
-
   alias Game.Account
   alias Game.Command.Move
   alias Game.Command.Pager
@@ -81,7 +79,6 @@ defmodule Game.Session.Process do
     %{user: user, save: save, session_started_at: session_started_at, stats: stats} = state
     Session.Registry.unregister()
     @room.leave(save.room_id, {:user, user})
-    clear_target(state, {:user, user})
     user |> Account.save_session(save, session_started_at, Timex.now(), stats)
     {:stop, :normal, state}
   end
@@ -172,10 +169,6 @@ defmodule Game.Session.Process do
 
   def handle_cast({:targeted, player}, state) do
     {:noreply, SessionCharacter.targeted(state, player)}
-  end
-
-  def handle_cast({:remove_target, character}, state) do
-    {:noreply, SessionCharacter.remove_target(state, character)}
   end
 
   def handle_cast({:apply_effects, effects, from, description}, state = %{state: "active"}) do

--- a/lib/web/npc.ex
+++ b/lib/web/npc.ex
@@ -259,7 +259,7 @@ defmodule Web.NPC do
 
     case changeset |> Repo.insert() do
       {:ok, npc_spawner} ->
-        npc_spawner = npc_spawner |> Repo.preload([:npc])
+        npc_spawner = npc_spawner |> Repo.preload([npc: [:npc_items]])
         Game.Zone.spawn_npc(npc_spawner.zone_id, npc_spawner)
         {:ok, npc_spawner}
 

--- a/test/game/command/move_test.exs
+++ b/test/game/command/move_test.exs
@@ -364,7 +364,6 @@ defmodule Game.Command.MoveTest do
     {:update, state} = Command.run(command, state)
 
     assert state.target == nil
-    assert_received {:"$gen_cast", {:remove_target, {:user, ^user}}}
     assert [{^socket, "Target.Clear", "{}"} | _] = @socket.get_push_gmcps()
 
     Registry.unregister()

--- a/test/game/npc/actions_test.exs
+++ b/test/game/npc/actions_test.exs
@@ -76,20 +76,20 @@ defmodule Game.NPC.ActionsTest do
     end
 
     test "triggers respawn", state do
-      _state = Actions.died(state)
+      _state = Actions.died(state, {:npc, state.npc})
 
       assert_receive :respawn
     end
 
     test "drops currency in the room", state do
-      _state = Actions.died(state)
+      _state = Actions.died(state, {:npc, state.npc})
 
       assert [{1, {:npc, _}, 51}] = @room.get_drop_currencies()
     end
 
     test "does not drop 0 currency", state do
       npc = %{state.npc | currency: 0}
-      _state = Actions.died(%{state | npc: npc})
+      _state = Actions.died(%{state | npc: npc}, {:npc, state.npc})
 
       assert [] = @room.get_drop_currencies()
     end
@@ -99,7 +99,7 @@ defmodule Game.NPC.ActionsTest do
     end
 
     test "drops items in the room", state do
-      _state = Actions.died(state)
+      _state = Actions.died(state, {:npc, state.npc})
 
       assert [{1, {:npc, _}, %{id: 1}}, {1, {:npc, _}, %{id: 2}}] = @room.get_drops()
     end

--- a/test/game/npc/actions_test.exs
+++ b/test/game/npc/actions_test.exs
@@ -72,7 +72,7 @@ defmodule Game.NPC.ActionsTest do
       npc = %{id: 1, name: "NPC", currency: 100, npc_items: npc_items}
       npc_spawner = %{id: 1, spawn_interval: 0}
 
-      %{room_id: 1, npc: npc, npc_spawner: npc_spawner, is_targeting: [], target: nil}
+      %{room_id: 1, npc: npc, npc_spawner: npc_spawner, target: nil}
     end
 
     test "triggers respawn", state do
@@ -123,7 +123,6 @@ defmodule Game.NPC.ActionsTest do
         room_id: 1,
         npc: npc,
         npc_spawner: npc_spawner,
-        is_targeting: MapSet.new(),
         continuous_effects: [effect],
       }
 

--- a/test/game/npc/events_test.exs
+++ b/test/game/npc/events_test.exs
@@ -14,6 +14,34 @@ defmodule Game.NPC.EventsTest do
     @room.clear_says()
   end
 
+  describe "character/died" do
+    setup do
+      npc = %{id: 1, name: "Mayor", events: [], stats: base_stats()}
+      user = %{id: 2, name: "Player"}
+
+      state = %State{room_id: 1, npc: npc, target: nil}
+
+      @room._room()
+      |> Map.put(:npcs, [npc])
+      |> Map.put(:players, [%{id: 1, name: "Player"}])
+      |> @room.set_room()
+
+      event = {"character/died", {:user, user}, :character, {:npc, npc}}
+
+      %{state: state, event: event}
+    end
+
+    test "clears the target if they were targetting the character", %{state: state, event: event} do
+      state = %{state | target: {:user, 2}}
+      {:update, state} = Events.act_on(state, event)
+      assert is_nil(state.target)
+    end
+
+    test "does nothing if the target does not match", %{state: state, event: event} do
+      :ok = Events.act_on(state, event)
+    end
+  end
+
   describe "combat/tick" do
     setup do
       event = %{

--- a/test/game/npc_test.exs
+++ b/test/game/npc_test.exs
@@ -23,10 +23,11 @@ defmodule Game.NPCTest do
 
   test "applying continuous effects - damage over time" do
     effect = %{kind: "damage/over-time", type: :slashing, every: 10, count: 3, amount: 10}
+    from = {:user, %{id: 2}}
 
     state = %State{npc: %{id: 1, name: "NPC", stats: %{health: 25}}, continuous_effects: []}
-    {:noreply, state} = NPC.handle_cast({:apply_effects, [effect], {:user, %{id: 2}}, "description"}, state)
-    [effect] = state.continuous_effects
+    {:noreply, state} = NPC.handle_cast({:apply_effects, [effect], from, "description"}, state)
+    [{^from, effect}] = state.continuous_effects
     assert effect.kind == "damage/over-time"
     assert effect.id
 

--- a/test/game/npc_test.exs
+++ b/test/game/npc_test.exs
@@ -8,6 +8,7 @@ defmodule Game.NPCTest do
   alias Game.Session.Registry
 
   setup do
+    @room.clear_notifies()
     @room.clear_says()
     @room.clear_leaves()
   end
@@ -63,8 +64,6 @@ defmodule Game.NPCTest do
   end
 
   test "applying effects - died" do
-    Registry.register(%{id: 2})
-
     effect = %{kind: "damage", type: :slashing, amount: 10}
 
     is_targeting = MapSet.new |> MapSet.put({:user, 2})
@@ -75,8 +74,7 @@ defmodule Game.NPCTest do
     assert state.npc.stats.health == 0
 
     assert [{1, {:npc, _}, :death}] = @room.get_leaves()
-
-    assert_received {:"$gen_cast", {:died, {:npc, _}}}
+    assert [{1, {"character/died", _, _, _}}] = @room.get_notifies()
 
     Registry.unregister()
   end

--- a/test/game/npc_test.exs
+++ b/test/game/npc_test.exs
@@ -13,39 +13,10 @@ defmodule Game.NPCTest do
     @room.clear_leaves()
   end
 
-  test "being targeted tracks the target" do
-    targeter = {:user, %{id: 10, name: "Player"}}
-
-    {:noreply, state} =
-      NPC.handle_cast({:targeted, targeter}, %{npc: %{name: "NPC"}, is_targeting: MapSet.new()})
-
-    assert state.is_targeting |> MapSet.size() == 1
-    assert state.is_targeting |> MapSet.member?({:user, 10})
-  end
-
-  test "a player removing a target stops tracking them" do
-    targeter = {:user, %{id: 10, name: "Player"}}
-    is_targeting = MapSet.new() |> MapSet.put({:user, 10})
-
-    {:noreply, state} = NPC.handle_cast({:remove_target, targeter}, %{is_targeting: is_targeting})
-
-    assert state.is_targeting |> MapSet.size() == 0
-    refute state.is_targeting |> MapSet.member?({:user, 10})
-  end
-
-  describe "a player died" do
-    test "clears their target if that player was their target" do
-      target = {:user, %{id: 10, name: "Player"}}
-      {:noreply, state} = NPC.handle_cast({:died, target}, %{target: {:user, 10}, npc: %{id: 10}})
-
-      assert is_nil(state.target)
-    end
-  end
-
   test "applying effects" do
     effect = %{kind: "damage", type: :slashing, amount: 10}
 
-    state = %State{npc: %{id: 1, name: "NPC", stats: %{health: 25}}, is_targeting: MapSet.new()}
+    state = %State{npc: %{id: 1, name: "NPC", stats: %{health: 25}}}
     {:noreply, state} = NPC.handle_cast({:apply_effects, [effect], {:user, %{id: 2}}, "description"}, state)
     assert state.npc.stats.health == 15
   end
@@ -53,7 +24,7 @@ defmodule Game.NPCTest do
   test "applying continuous effects - damage over time" do
     effect = %{kind: "damage/over-time", type: :slashing, every: 10, count: 3, amount: 10}
 
-    state = %State{npc: %{id: 1, name: "NPC", stats: %{health: 25}}, is_targeting: MapSet.new(), continuous_effects: []}
+    state = %State{npc: %{id: 1, name: "NPC", stats: %{health: 25}}, continuous_effects: []}
     {:noreply, state} = NPC.handle_cast({:apply_effects, [effect], {:user, %{id: 2}}, "description"}, state)
     [effect] = state.continuous_effects
     assert effect.kind == "damage/over-time"
@@ -66,10 +37,9 @@ defmodule Game.NPCTest do
   test "applying effects - died" do
     effect = %{kind: "damage", type: :slashing, amount: 10}
 
-    is_targeting = MapSet.new |> MapSet.put({:user, 2})
     npc = %{currency: 0, npc_items: [], id: 1, name: "NPC", stats: %{health: 10}}
     npc_spawner = %{spawn_interval: 0}
-    state = %State{room_id: 1, npc: npc, npc_spawner: npc_spawner, is_targeting: is_targeting}
+    state = %State{room_id: 1, npc: npc, npc_spawner: npc_spawner}
     {:noreply, state} = NPC.handle_cast({:apply_effects, [effect], {:user, %{id: 2}}, "description"}, state)
     assert state.npc.stats.health == 0
 

--- a/test/game/session_test.exs
+++ b/test/game/session_test.exs
@@ -202,16 +202,18 @@ defmodule Game.SessionTest do
     effect = %{kind: "damage/over-time", type: :slashing, every: 10, count: 3, amount: 10}
     stats = %{health: 25}
     user = %{id: 2, name: "user", class: class_attributes(%{})}
+    from = {:npc, %{id: 1, name: "Bandit"}}
     state = %State{socket: socket, state: "active", mode: "commands", user: user, save: %{room_id: 1, stats: stats}, is_targeting: MapSet.new()}
 
-    {:noreply, state} = Process.handle_cast({:apply_effects, [effect], {:npc, %{id: 1, name: "Bandit"}}, "description"}, state)
+    {:noreply, state} = Process.handle_cast({:apply_effects, [effect], from, "description"}, state)
 
     assert state.save.stats.health == 15
     assert_received {:"$gen_cast", {:echo, ~s(description\n10 slashing damage is dealt.)}}
 
-    [effect] = state.continuous_effects
+    [{^from, effect}] = state.continuous_effects
     assert effect.kind == "damage/over-time"
     assert effect.id
+
     effect_id = effect.id
     assert_receive {:continuous_effect, ^effect_id}
   end

--- a/test/game/session_test.exs
+++ b/test/game/session_test.exs
@@ -296,16 +296,6 @@ defmodule Game.SessionTest do
     end
   end
 
-  test "a player removing a target stops tracking them", %{socket: socket} do
-    targeter = {:user, %{id: 10, name: "Player"}}
-    is_targeting = MapSet.new() |> MapSet.put({:user, 10})
-
-    {:noreply, state} = Process.handle_cast({:remove_target, targeter}, %{socket: socket, is_targeting: is_targeting})
-
-    assert state.is_targeting |> MapSet.size() == 0
-    refute state.is_targeting |> MapSet.member?({:user, 10})
-  end
-
   describe "channels" do
     setup do
       @socket.clear_messages()

--- a/test/support/room.ex
+++ b/test/support/room.ex
@@ -84,6 +84,24 @@ defmodule Test.Game.Room do
     Agent.update(__MODULE__, fn (state) -> Map.put(state, :leave, []) end)
   end
 
+  def notify(id, _sender, event) do
+    start_link()
+    Agent.update(__MODULE__, fn (state) ->
+      notifys = Map.get(state, :notify, [])
+      Map.put(state, :notify, notifys ++ [{id, event}])
+    end)
+  end
+
+  def get_notifies() do
+    start_link()
+    Agent.get(__MODULE__, fn (state) -> Map.get(state, :notify, []) end)
+  end
+
+  def clear_notifies() do
+    start_link()
+    Agent.update(__MODULE__, fn (state) -> Map.put(state, :notify, []) end)
+  end
+
   def say(id, _sender, message) do
     start_link()
     Agent.update(__MODULE__, fn (state) ->


### PR DESCRIPTION
Removes a lot of weird tracking, instead keeps it more simple and broadcasts a character died message when the character dies. Players will know it was them who killed the NPC and gain experience for it.