### PR TITLE
Recall to the zone's graveyard

### DIFF
--- a/lib/game/command.ex
+++ b/lib/game/command.ex
@@ -96,6 +96,7 @@ defmodule Game.Command do
     Command.PickUp,
     Command.Quest,
     Command.Quit,
+    Command.Recall,
     Command.Shops,
     Command.Tell,
     Command.Train,

--- a/lib/game/command/recall.ex
+++ b/lib/game/command/recall.ex
@@ -1,0 +1,84 @@
+defmodule Game.Command.Recall do
+  @moduledoc """
+  The "recall" command
+  """
+
+  use Game.Command
+  use Game.Zone
+
+  commands(["recall"], parse: false)
+
+  @impl Game.Command
+  def help(:topic), do: "Recall"
+  def help(:short), do: "Recall to the zone's graveyard"
+
+  def help(:full) do
+    """
+    #{help(:short)}. Spends all movement points, and you must have >90% left.
+
+    [ ] > {white}recall{/white}
+    """
+  end
+
+  @impl Game.Command
+  @doc """
+  Parse the command into arguments
+
+      iex> Game.Command.Recall.parse("recall")
+      {}
+
+      iex> Game.Command.Recall.parse("recall extra")
+      {:error, :bad_parse, "recall extra"}
+
+      iex> Game.Command.Recall.parse("unknown hi")
+      {:error, :bad_parse, "unknown hi"}
+  """
+  @spec parse(String.t()) :: {atom}
+  def parse(command)
+  def parse("recall"), do: {}
+
+  @impl Game.Command
+  @doc """
+  Send to all connected players
+  """
+  def run(command, state)
+
+  def run({}, state) do
+    state
+    |> check_movement_points()
+    |> maybe_recall()
+  end
+
+  def check_movement_points(state = %{save: %{stats: stats}}) do
+    case stats.move_points / stats.max_move_points do
+      ratio when ratio > 0.9 ->
+        state
+
+      _ ->
+        min = round(stats.max_move_points * 0.9)
+        state.socket |> @socket.echo("You do not have enough movement points to recall. You must have at least #{min}mp first.")
+    end
+  end
+
+  defp maybe_recall(:ok), do: :ok
+  defp maybe_recall(state = %{save: save}) do
+    room = save.room_id |> @room.look()
+
+    case @zone.graveyard(room.zone_id) do
+      {:ok, graveyard_id} ->
+        save = %{save | stats: %{save.stats | move_points: 0}}
+
+        user = %{state.user | save: save}
+        state = %{state | user: user, save: save}
+
+        Session.teleport(self(), graveyard_id)
+
+        state.socket |> @socket.echo("Recalling to the zone's graveyard...")
+
+        {:update, state}
+
+      {:error, :no_graveyard} ->
+        state.socket |> @socket.echo("You cannot recall here.")
+    end
+  end
+end

--- a/test/game/command/recall_test.exs
+++ b/test/game/command/recall_test.exs
@@ -1,0 +1,49 @@
+defmodule Game.Command.RecallTest do
+  use Data.ModelCase
+  doctest Game.Command.Recall
+
+  alias Game.Command.Recall
+
+  @socket Test.Networking.Socket
+  @room Test.Game.Room
+  @zone Test.Game.Zone
+
+  setup do
+    @socket.clear_messages()
+    user = create_user(%{name: "user", password: "password"})
+    %{state: %{socket: :socket, user: user, save: user.save}}
+  end
+
+  describe "recalling to a graveyard" do
+    test "teleports to the zone's graveyard", %{state: state} do
+      @room.set_room(@room._room())
+      @zone.set_graveyard({:ok, 2})
+
+      {:update, state} = Recall.run({}, state)
+
+      assert state.save.stats.move_points == 0
+      assert_received {:"$gen_cast", {:teleport, 2}}
+    end
+
+    test "not enough movement", %{state: state} do
+      %{save: save}  = state
+
+      state = %{state | save: %{save | stats: %{save.stats | move_points: 5, max_move_points: 10}}}
+
+      :ok = Recall.run({}, state)
+
+      [{_socket, echo}] = @socket.get_echos()
+      assert Regex.match?(~r{do not have enough movement}, echo)
+    end
+
+    test "zone does not have a graveyard", %{state: state} do
+      @room.set_room(@room._room())
+      @zone.set_graveyard({:error, :no_graveyard})
+
+      :ok = Recall.run({}, state)
+
+      [{_socket, echo}] = @socket.get_echos()
+      assert Regex.match?(~r{you cannot recall here}i, echo)
+    end
+  end
+end

--- a/test/game/command_test.exs
+++ b/test/game/command_test.exs
@@ -237,6 +237,10 @@ defmodule Game.CommandTest do
     test "train", %{user: user} do
       assert %Command{module: Command.Train, args: {:list}} = Command.parse("train list", user)
     end
+
+    test "recall", %{user: user} do
+      assert %Command{module: Command.Recall, args: {}} = Command.parse("recall", user)
+    end
   end
 
   test "limit commands to be above 0 hp to perform", %{socket: socket} do


### PR DESCRIPTION
Requires 90% of your movement points available and spends all of them to
recall.