### PR TITLE
Skill whitelist

### DIFF
--- a/lib/data/effect.ex
+++ b/lib/data/effect.ex
@@ -55,6 +55,19 @@ defmodule Data.Effect do
 
   @behaviour Ecto.Type
 
+  @doc """
+  A list of all types in the system.
+  """
+  def types() do
+    [
+      "damage",
+      "damage/over-time",
+      "damage/type",
+      "recover",
+      "stats",
+    ]
+  end
+
   @impl Ecto.Type
   def type, do: :map
 

--- a/lib/data/skill.ex
+++ b/lib/data/skill.ex
@@ -18,6 +18,7 @@ defmodule Data.Skill do
     field(:user_text, :string)
     field(:usee_text, :string)
     field(:command, :string)
+    field(:white_list_effects, {:array, :string}, default: [])
     field(:effects, {:array, Effect})
     field(:tags, {:array, :string}, default: [])
     field(:is_global, :boolean, default: false)
@@ -38,6 +39,7 @@ defmodule Data.Skill do
       :user_text,
       :usee_text,
       :command,
+      :white_list_effects,
       :effects,
       :tags,
       :is_global
@@ -50,10 +52,32 @@ defmodule Data.Skill do
       :user_text,
       :usee_text,
       :command,
+      :white_list_effects,
       :effects,
       :tags,
       :is_global
     ])
     |> validate_effects()
+    |> validate_white_list()
+  end
+
+  defp validate_white_list(changeset) do
+    case get_field(changeset, :white_list_effects) do
+      nil ->
+        changeset
+
+      white_list_effects ->
+        _validate_white_list(changeset, white_list_effects)
+    end
+  end
+
+  defp _validate_white_list(changeset, white_list_effects) do
+    case Enum.all?(white_list_effects, & &1 in Effect.types()) do
+      true ->
+        changeset
+
+      false ->
+        add_error(changeset, :white_list_effects, "must all be a real type")
+    end
   end
 end

--- a/lib/game/command/skills.ex
+++ b/lib/game/command/skills.ex
@@ -144,7 +144,12 @@ defmodule Game.Command.Skills do
         save = %{save | stats: stats}
 
         player_effects = save |> Item.effects_on_player()
-        effects = stats |> Effect.calculate(player_effects ++ skill.effects)
+
+        effects =
+          player_effects ++ skill.effects
+          |> Skill.filter_effects(skill)
+
+        effects = stats |> Effect.calculate(effects)
 
         Character.apply_effects(
           target,

--- a/lib/game/format.ex
+++ b/lib/game/format.ex
@@ -344,7 +344,7 @@ defmodule Game.Format do
   end
 
   def maybe_items(room, items) do
-    case length(items) == 0 and room.currency == 0 do
+    case Enum.empty?(items) and room.currency == 0 do
       true ->
         ""
 

--- a/lib/game/skill.ex
+++ b/lib/game/skill.ex
@@ -47,4 +47,14 @@ defmodule Game.Skill do
     cost = 1000 - 100 * (save.level - skill.level)
     Enum.max([cost, 100])
   end
+
+  @doc """
+  Filter out effects that don't match the skill's whitelist
+  """
+  @spec filter_effects([Effect.t()], Skill.t()) :: [Effect.t()]
+  def filter_effects(effects, skill) do
+    Enum.filter(effects, fn effect ->
+      effect.kind in skill.white_list_effects
+    end)
+  end
 end

--- a/lib/web/templates/admin/skill/_form.html.eex
+++ b/lib/web/templates/admin/skill/_form.html.eex
@@ -67,6 +67,13 @@
       </div>
 
       <div class="form-group">
+        <%= label f, :white_list_effects %>
+        <%= multiple_select f, :white_list_effects, Effect.types(), multiple: true, class: "form-control", size: 5 %>
+        <%= error_tag f, :white_list_effects %>
+        <span class="help-block"><%= Help.get("skill.white_list_effects") %></span>
+      </div>
+
+      <div class="form-group">
         <%= label f, :effects %>
         <%= textarea f, :effects, value: @changeset |> json_field(:effects), class: "form-control", rows: 15 %>
         <%= error_tag f, :effects %>

--- a/lib/web/templates/admin/skill/show.html.eex
+++ b/lib/web/templates/admin/skill/show.html.eex
@@ -68,6 +68,19 @@
                 <td><span class="label label-default"><%= @skill.is_global %></span></td>
               </tr>
               <tr>
+                <th>
+                  White Listed Effect Types
+                  <%= SharedView.help_tooltip("skill.white_list_effects") %>
+                </th>
+                <td>
+                  <ul>
+                    <%= Enum.map(@skill.white_list_effects, fn effect -> %>
+                      <li><code><%= effect %></code></li>
+                    <% end) %>
+                  </ul>
+                </td>
+              </tr>
+              <tr>
                 <th>Effects</th>
                 <td><pre><%= @skill |> json_field(:effects) %></pre></td>
               </tr>

--- a/lib/web/views/admin/skill_view.ex
+++ b/lib/web/views/admin/skill_view.ex
@@ -1,6 +1,7 @@
 defmodule Web.Admin.SkillView do
   use Web, :view
 
+  alias Data.Effect
   alias Web.Admin.SharedView
 
   import Ecto.Changeset

--- a/priv/help/web.help
+++ b/priv/help/web.help
@@ -58,6 +58,9 @@ room.items:
 room.zone_exit:
   A room that is a zone exit will always show up in the room selection box when creating exits, not just for the current zone.
 
+skill.white_list_effects:
+  Effects in this whitelist will be calculated when using the skill. Anything not in the list will be filtered out.
+
 zone.name:
   This will be seen in the player's map.
 

--- a/priv/repo/migrations/20180302041502_add_white_list_effects_to_skills.exs
+++ b/priv/repo/migrations/20180302041502_add_white_list_effects_to_skills.exs
@@ -1,0 +1,9 @@
+defmodule Data.Repo.Migrations.AddWhiteListEffectsToSkills do
+  use Ecto.Migration
+
+  def change do
+    alter table(:skills) do
+      add :white_list_effects, {:array, :string}, default: fragment("'{}'"), null: false
+    end
+  end
+end

--- a/test/data/skill_test.exs
+++ b/test/data/skill_test.exs
@@ -24,4 +24,16 @@ defmodule Data.SkillTest do
       assert changeset.errors[:effects]
     end
   end
+
+  describe "validates white list effects" do
+    test "real types are valid" do
+      changeset = %Skill{} |> Skill.changeset(%{white_list_effects: ["damage"]})
+      refute changeset.errors[:white_list_effects]
+    end
+
+    test "unknown types are invalid" do
+      changeset = %Skill{} |> Skill.changeset(%{white_list_effects: ["unknown"]})
+      assert changeset.errors[:white_list_effects]
+    end
+  end
 end

--- a/test/game/command/skills_test.exs
+++ b/test/game/command/skills_test.exs
@@ -26,7 +26,7 @@ defmodule Game.Command.SkillsTest do
       description: "Slash",
       user_text: "Slash at your {target}",
       usee_text: "You were slashed at",
-      effects: [],
+      effects: [%{kind: "damage", type: :slashing, amount: 0}],
     })
     insert_skill(slash)
 

--- a/test/game/skill_test.exs
+++ b/test/game/skill_test.exs
@@ -1,4 +1,16 @@
 defmodule Game.SkillTest do
   use ExUnit.Case
   doctest Game.Skill
+
+  alias Game.Skill
+
+  test "filtering out effects that don't match" do
+    skill = %Data.Skill{white_list_effects: ["damage"]}
+    effects = [
+      %{kind: "damage"},
+      %{kind: "damage/over-time"},
+    ]
+
+    assert Skill.filter_effects(effects, skill) == [%{kind: "damage"}]
+  end
 end


### PR DESCRIPTION
Limit what effects go into the calculation of a skill. This way a healing spell/skill won't include the damage of the knife you're holding in the usage of the skill.