### PR TITLE
Add `_points` to the health stats

### DIFF
--- a/assets/app/js/gmcp.js
+++ b/assets/app/js/gmcp.js
@@ -29,14 +29,14 @@ let character = (channel, data) => {
  * Character.Vitals module
  */
 let characterVitals = (channel, data) => {
-  let healthWidth = data.health / data.max_health;
+  let healthWidth = data.health_points / data.max_health_points;
   let skillWidth = data.skill_points / data.max_skill_points;
   let moveWidth = data.move_points / data.max_move_points;
 
   let health = _.first(Sizzle("#health .percentage"));
   health.style.width = `${healthWidth * 100}%`;
   let healthStat = _.first(Sizzle("#health .stat"));
-  healthStat.innerHTML = `${data.health}/${data.max_health} hp`;
+  healthStat.innerHTML = `${data.health_points}/${data.max_health_points} hp`;
 
   let skill = _.first(Sizzle("#skills .percentage"));
   skill.style.width = `${skillWidth * 100}%`;

--- a/docs/game/gmcp.md
+++ b/docs/game/gmcp.md
@@ -39,9 +39,9 @@ Character.Vitals {
   "move_points": 10,
   "max_skill_points": 20,
   "max_move_points": 10,
-  "max_health": 30,
+  "max_health_points": 30,
   "intelligence": 15,
-  "health": 30,
+  "health_points": 30,
   "dexterity": 15
 }
 ```

--- a/lib/data/class.ex
+++ b/lib/data/class.ex
@@ -13,7 +13,7 @@ defmodule Data.Class do
     field(:description, :string)
     field(:each_level_stats, Stats)
 
-    field(:regen_health, :integer)
+    field(:regen_health_points, :integer)
     field(:regen_skill_points, :integer)
 
     has_many(:class_skills, ClassSkill)
@@ -26,14 +26,14 @@ defmodule Data.Class do
       :name,
       :description,
       :each_level_stats,
-      :regen_health,
+      :regen_health_points,
       :regen_skill_points
     ])
     |> validate_required([
       :name,
       :description,
       :each_level_stats,
-      :regen_health,
+      :regen_health_points,
       :regen_skill_points
     ])
     |> validate_stats()

--- a/lib/data/save.ex
+++ b/lib/data/save.ex
@@ -184,6 +184,27 @@ defmodule Data.Save do
     end
   end
 
+  defp _migrate(save = %{version: 6, stats: stats}) when stats != nil do
+    stats =
+      stats
+      |> Map.put(:health_points, stats.health)
+      |> Map.put(:max_health_points, stats.max_health)
+      |> Map.delete(:health)
+      |> Map.delete(:max_health)
+
+    save
+    |> Map.put(:stats, stats)
+    |> Map.put(:version, 7)
+    |> _migrate()
+  end
+
+  # for the startin save which has empty stats, migrate the version forward
+  defp _migrate(save = %{version: 6}) do
+    save
+    |> Map.put(:version, 7)
+    |> _migrate()
+  end
+
   defp _migrate(save = %{version: 5}) do
     save
     |> Map.put(:config, %{hints: true})

--- a/lib/data/stats.ex
+++ b/lib/data/stats.ex
@@ -8,8 +8,8 @@ defmodule Data.Stats do
   alias Data.Stats.Damage
 
   @type character :: %{
-          health: integer,
-          max_health: integer,
+          health_points: integer,
+          max_health_points: integer,
           skill_points: integer,
           max_skill_points: integer,
           move_points: integer,
@@ -63,8 +63,9 @@ defmodule Data.Stats do
   @spec default(Stats.t()) :: Stats.t()
   def default(stats) do
     stats
-    |> ensure(:health, 10)
-    |> ensure(:max_health, 10)
+    |> migrate()
+    |> ensure(:health_points, 10)
+    |> ensure(:max_health_points, 10)
     |> ensure(:skill_points, 10)
     |> ensure(:max_skill_points, 10)
     |> ensure(:move_points, 10)
@@ -74,6 +75,16 @@ defmodule Data.Stats do
     |> ensure(:intelligence, 10)
     |> ensure(:wisdom, 10)
   end
+
+  defp migrate(stats = %{health: health, max_health: max_health}) do
+    stats
+    |> Map.put(:health_points, health)
+    |> Map.put(:max_health_points, max_health)
+    |> Map.delete(:health)
+    |> Map.delete(:max_health)
+  end
+
+  defp migrate(stats), do: stats
 
   defp ensure(stats, field, default) do
     case Map.has_key?(stats, field) do
@@ -96,9 +107,9 @@ defmodule Data.Stats do
   def fields(),
     do: [
       :dexterity,
-      :health,
+      :health_points,
       :intelligence,
-      :max_health,
+      :max_health_points,
       :max_move_points,
       :max_skill_points,
       :move_points,
@@ -110,7 +121,7 @@ defmodule Data.Stats do
   @doc """
   Validate a character's stats
 
-      iex> Data.Stats.valid_character?(%{health: 50, strength: 10})
+      iex> Data.Stats.valid_character?(%{health_points: 50, strength: 10})
       false
 
       iex> Data.Stats.valid_character?(%{})
@@ -118,8 +129,8 @@ defmodule Data.Stats do
   """
   @spec valid_character?(Stats.character()) :: boolean()
   def valid_character?(stats) do
-    keys(stats) == fields() && is_integer(stats.dexterity) && is_integer(stats.health) &&
-      is_integer(stats.intelligence) && is_integer(stats.max_health) && is_integer(stats.strength) &&
+    keys(stats) == fields() && is_integer(stats.dexterity) && is_integer(stats.health_points) &&
+      is_integer(stats.intelligence) && is_integer(stats.max_health_points) && is_integer(stats.strength) &&
       is_integer(stats.skill_points) && is_integer(stats.max_skill_points) &&
       is_integer(stats.wisdom)
   end

--- a/lib/game/character/helpers.ex
+++ b/lib/game/character/helpers.ex
@@ -45,14 +45,14 @@ defmodule Game.Character.Helpers do
   @doc """
   Determine if the Character is alive still
 
-      iex> Game.Character.Helpers.is_alive?(%{stats: %{health: 10}})
+      iex> Game.Character.Helpers.is_alive?(%{stats: %{health_points: 10}})
       true
 
-      iex> Game.Character.Helpers.is_alive?(%{stats: %{health: -1}})
+      iex> Game.Character.Helpers.is_alive?(%{stats: %{health_points: -1}})
       false
   """
   @spec is_alive?(map()) :: boolean()
   def is_alive?(save)
-  def is_alive?(%{stats: %{health: health}}) when health > 0, do: true
+  def is_alive?(%{stats: %{health_points: health_points}}) when health_points > 0, do: true
   def is_alive?(_), do: false
 end

--- a/lib/game/command.ex
+++ b/lib/game/command.ex
@@ -191,7 +191,7 @@ defmodule Game.Command do
     case module.must_be_alive? do
       true ->
         case state do
-          %{save: %{stats: %{health: health}}} when health <= 0 ->
+          %{save: %{stats: %{health_points: health_points}}} when health_points <= 0 ->
             socket |> @socket.echo("You are passed out and cannot perform this action.")
             :ok
 

--- a/lib/game/command/target.ex
+++ b/lib/game/command/target.ex
@@ -85,7 +85,7 @@ defmodule Game.Command.Target do
   @spec target_user(User.t(), pid, map) :: :ok | {:update, map}
   def target_user(user, socket, state)
 
-  def target_user(user = %{save: %{stats: %{health: health}}}, socket, _state) when health < 1 do
+  def target_user(user = %{save: %{stats: %{health_points: health_points}}}, socket, _state) when health_points < 1 do
     socket |> @socket.echo("#{Format.target_name({:user, user})} could not be targeted.")
     :ok
   end

--- a/lib/game/effect.ex
+++ b/lib/game/effect.ex
@@ -139,8 +139,8 @@ defmodule Game.Effect do
   Apply effects to stats.
 
       iex> effects = [%{kind: "damage", type: :slashing, amount: 10}]
-      iex> Game.Effect.apply(effects, %{health: 25})
-      %{health: 15}
+      iex> Game.Effect.apply(effects, %{health_points: 25})
+      %{health_points: 15}
   """
   @spec apply([Effect.t()], Stats.t()) :: Stats.t()
   def apply(effects, stats) do
@@ -151,26 +151,26 @@ defmodule Game.Effect do
   Apply an effect to stats
 
       iex> effect = %{kind: "damage", type: :slashing, amount: 10}
-      iex> Game.Effect.apply_effect(effect, %{health: 25})
-      %{health: 15}
+      iex> Game.Effect.apply_effect(effect, %{health_points: 25})
+      %{health_points: 15}
   """
   @spec apply_effect(Effect.t(), Stats.t()) :: Stats.t()
   def apply_effect(effect, stats)
 
   def apply_effect(effect = %{kind: "damage"}, stats) do
-    %{health: health} = stats
-    Map.put(stats, :health, health - effect.amount)
+    %{health_points: health_points} = stats
+    Map.put(stats, :health_points, health_points - effect.amount)
   end
 
   def apply_effect(effect = %{kind: "damage/over-time"}, stats) do
-    %{health: health} = stats
-    Map.put(stats, :health, health - effect.amount)
+    %{health_points: health_points} = stats
+    Map.put(stats, :health_points, health_points - effect.amount)
   end
 
   def apply_effect(effect = %{kind: "recover", type: "health"}, stats) do
-    %{health: health, max_health: max_health} = stats
-    health = max_recover(health, effect.amount, max_health)
-    %{stats | health: health}
+    %{health_points: health_points, max_health_points: max_health_points} = stats
+    health_points = max_recover(health_points, effect.amount, max_health_points)
+    %{stats | health_points: health_points}
   end
 
   def apply_effect(effect = %{kind: "recover", type: "skill"}, stats) do

--- a/lib/game/format.ex
+++ b/lib/game/format.ex
@@ -48,7 +48,7 @@ defmodule Game.Format do
 
   Example:
 
-      iex> stats = %{health: 50, max_health: 75, skill_points: 9, max_skill_points: 10, move_points: 4, max_move_points: 10}
+      iex> stats = %{health_points: 50, max_health_points: 75, skill_points: 9, max_skill_points: 10, move_points: 4, max_move_points: 10}
       ...> config = %{prompt: "%h/%Hhp %s/%Ssp %m/%Mmv %xxp"}
       ...> Game.Format.prompt(%{name: "user"}, %{experience_points: 1010, stats: stats, config: config})
       "[50/75hp 9/10sp 4/10mv 10xp] > "
@@ -60,8 +60,8 @@ defmodule Game.Format do
     exp = rem(exp, 1000)
 
     "[#{config.prompt}] > "
-    |> String.replace("%h", to_string(stats.health))
-    |> String.replace("%H", to_string(stats.max_health))
+    |> String.replace("%h", to_string(stats.health_points))
+    |> String.replace("%H", to_string(stats.max_health_points))
     |> String.replace("%s", to_string(stats.skill_points))
     |> String.replace("%S", to_string(stats.max_skill_points))
     |> String.replace("%m", to_string(stats.move_points))
@@ -564,7 +564,7 @@ defmodule Game.Format do
       ["Level", save.level],
       ["XP", save.experience_points],
       ["Spent XP", save.spent_experience_points],
-      ["Health Points", "#{stats.health}/#{stats.max_health}"],
+      ["Health Points", "#{stats.health_points}/#{stats.max_health_points}"],
       ["Skill Points", "#{stats.skill_points}/#{stats.max_skill_points}"],
       ["Movement Points", "#{stats.move_points}/#{stats.max_move_points}"],
       ["Strength", stats.strength],

--- a/lib/game/npc/actions.ex
+++ b/lib/game/npc/actions.ex
@@ -33,7 +33,7 @@ defmodule Game.NPC.Actions do
   end
 
   def handle_respawn(state = %{npc: npc, npc_spawner: npc_spawner}) do
-    npc = %{npc | stats: %{npc.stats | health: npc.stats.max_health}}
+    npc = %{npc | stats: %{npc.stats | health_points: npc.stats.max_health_points}}
     npc_spawner.room_id |> @room.enter({:npc, npc}, :respawn)
     Events.broadcast(npc, "character/respawned")
     %{state | npc: npc, room_id: npc_spawner.room_id}
@@ -44,7 +44,7 @@ defmodule Game.NPC.Actions do
   """
   @spec maybe_died(map, map, Character.t()) :: :ok
   def maybe_died(stats, state, from)
-  def maybe_died(%{health: health}, state, from) when health < 1, do: died(state, from)
+  def maybe_died(%{health_points: health_points}, state, from) when health_points < 1, do: died(state, from)
   def maybe_died(_stats, state, _from), do: state
 
   @doc """

--- a/lib/game/npc/events.ex
+++ b/lib/game/npc/events.ex
@@ -270,7 +270,7 @@ defmodule Game.NPC.Events do
   @doc """
   Act on a tick event
   """
-  def act_on_tick(state = %{npc: %{stats: %{health: health}}}, _event) when health < 1, do: state
+  def act_on_tick(state = %{npc: %{stats: %{health_points: health_points}}}, _event) when health_points < 1, do: state
 
   def act_on_tick(state, event = %{action: %{type: "move"}}) do
     maybe_move_room(state, event)

--- a/lib/game/session/effects.ex
+++ b/lib/game/session/effects.ex
@@ -57,7 +57,7 @@ defmodule Game.Session.Effects do
   @spec maybe_died(User.t(), State.t(), Character.t()) :: :ok
   def maybe_died(user, state, from)
 
-  def maybe_died(user = %{save: %{stats: %{health: health}}}, state, from) when health < 1 do
+  def maybe_died(user = %{save: %{stats: %{health_points: health_points}}}, state, from) when health_points < 1 do
     user |> maybe_transport_to_graveyard()
 
     state.save.room_id

--- a/lib/game/session/process.ex
+++ b/lib/game/session/process.ex
@@ -278,9 +278,9 @@ defmodule Game.Session.Process do
   def handle_info({:resurrect, graveyard_id}, state) do
     %{save: %{stats: stats}} = state
 
-    case stats.health do
-      health when health < 1 ->
-        stats = Map.put(stats, :health, 1)
+    case stats.health_points do
+      health_points when health_points < 1 ->
+        stats = Map.put(stats, :health_points, 1)
         save = Map.put(state.save, :stats, stats)
         user = Map.put(state.user, :save, save)
 

--- a/lib/game/session/regen.ex
+++ b/lib/game/session/regen.ex
@@ -57,7 +57,7 @@ defmodule Game.Session.Regen do
   end
 
   defp hp_max?(%{save: save}) do
-    save.stats.health == save.stats.max_health
+    save.stats.health_points == save.stats.max_health_points
   end
 
   defp sp_max?(%{save: save}) do
@@ -107,7 +107,7 @@ defmodule Game.Session.Regen do
   def handle_regen(state = %{regen: %{count: count}}, count) do
     %{user: user = %{class: class}, save: save} = state
 
-    stats = Stats.regen(:health, save.stats, class.regen_health * save.level)
+    stats = Stats.regen(:health_points, save.stats, class.regen_health_points * save.level)
     stats = Stats.regen(:skill_points, stats, class.regen_skill_points * save.level)
 
     echo_health(save.stats, stats)
@@ -131,14 +131,14 @@ defmodule Game.Session.Regen do
   """
   @spec echo_health(Stats.t(), Stats.t()) :: nil
   def echo_health(starting_stats, stats) do
-    starting_hp = starting_stats.health
+    starting_hp = starting_stats.health_points
     starting_sp = starting_stats.skill_points
 
     case stats do
-      %{health: ^starting_hp, skill_points: ^starting_sp} ->
+      %{health_points: ^starting_hp, skill_points: ^starting_sp} ->
         nil
 
-      %{health: ^starting_hp} ->
+      %{health_points: ^starting_hp} ->
         echo(self(), "You regenerated some skill points.")
 
       %{skill_points: ^starting_sp} ->

--- a/lib/game/stats.ex
+++ b/lib/game/stats.ex
@@ -8,11 +8,11 @@ defmodule Game.Stats do
   @doc """
   Regen statistics (hp/sp) every few ticks
 
-    iex> Game.Stats.regen(:health, %{health: 10, max_health: 15}, 3)
-    %{health: 13, max_health: 15}
+    iex> Game.Stats.regen(:health_points, %{health_points: 10, max_health_points: 15}, 3)
+    %{health_points: 13, max_health_points: 15}
 
-    iex> Game.Stats.regen(:health, %{health: 13, max_health: 15}, 3)
-    %{health: 15, max_health: 15}
+    iex> Game.Stats.regen(:health_points, %{health_points: 13, max_health_points: 15}, 3)
+    %{health_points: 15, max_health_points: 15}
 
     iex> Game.Stats.regen(:skill_points, %{skill_points: 10, max_skill_points: 15}, 3)
     %{skill_points: 13, max_skill_points: 15}
@@ -29,10 +29,10 @@ defmodule Game.Stats do
   @spec regen(atom, Stats.t(), map) :: Stats.t()
   def regen(field, stats, regen)
 
-  def regen(:health, stats, health) do
-    case %{stats | health: stats.health + health} do
-      %{health: health, max_health: max_health} when health > max_health ->
-        %{stats | health: max_health}
+  def regen(:health_points, stats, health_points) do
+    case %{stats | health_points: stats.health_points + health_points} do
+      %{health_points: health_points, max_health_points: max_health_points} when health_points > max_health_points ->
+        %{stats | health_points: max_health_points}
 
       stats ->
         stats

--- a/lib/web/templates/admin/class/_form.html.eex
+++ b/lib/web/templates/admin/class/_form.html.eex
@@ -25,9 +25,9 @@
       </div>
 
       <div class="form-group">
-        <%= label f, :regen_health %>
-        <%= text_input f, :regen_health, class: "form-control" %>
-        <%= error_tag f, :regen_health %>
+        <%= label f, :regen_health_points %>
+        <%= text_input f, :regen_health_points, class: "form-control" %>
+        <%= error_tag f, :regen_health_points %>
         <span class="help-block">Number of health each regen tick will give.</span>
       </div>
 

--- a/lib/web/templates/admin/class/show.html.eex
+++ b/lib/web/templates/admin/class/show.html.eex
@@ -40,7 +40,7 @@
             </tr>
             <tr>
               <th>Regen Health</th>
-              <td><%= @class.regen_health %></td>
+              <td><%= @class.regen_health_points %></td>
             </tr>
             <tr>
               <th>Regen Skill Points</th>

--- a/lib/web/templates/race/show.html.eex
+++ b/lib/web/templates/race/show.html.eex
@@ -10,7 +10,7 @@
       <legend>Starting Stats</legend>
       <tr>
         <th>Health</th>
-        <td><%= @race |> stat(:health) %>/<%= @race |> stat(:max_health) %></td>
+        <td><%= @race |> stat(:health_points) %>/<%= @race |> stat(:max_health_points) %></td>
       </tr>
       <tr>
         <th>Skill Points</th>

--- a/priv/repo/migrations/20180311232623_rename_health_fields.exs
+++ b/priv/repo/migrations/20180311232623_rename_health_fields.exs
@@ -1,0 +1,7 @@
+defmodule Data.Repo.Migrations.RenameHealthFields do
+  use Ecto.Migration
+
+  def change do
+    rename table(:classes), :regen_health, to: :regen_health_points
+  end
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -222,8 +222,8 @@ defmodule Seeds do
     create_exit(%{west_id: shack.id, east_id: forest_path.id})
 
     stats = %{
-      health: 25,
-      max_health: 25,
+      health_points: 25,
+      max_health_points: 25,
       skill_points: 10,
       max_skill_points: 10,
       move_points: 10,
@@ -316,8 +316,8 @@ defmodule Seeds do
       name: "Human",
       description: "A human",
       starting_stats: %{
-        health: 40,
-        max_health: 40,
+        health_points: 40,
+        max_health_points: 40,
         skill_points: 15,
         max_skill_points: 15,
         move_points: 15,
@@ -333,8 +333,8 @@ defmodule Seeds do
       name: "Dwarf",
       description: "A dwarf",
       starting_stats: %{
-        health: 50,
-        max_health: 50,
+        health_points: 50,
+        max_health_points: 50,
         skill_points: 15,
         max_skill_points: 15,
         move_points: 15,
@@ -350,8 +350,8 @@ defmodule Seeds do
       name: "Elf",
       description: "An elf",
       starting_stats: %{
-        health: 15,
-        max_health: 35,
+        health_points: 15,
+        max_health_points: 35,
         skill_points: 35,
         max_skill_points: 15,
         move_points: 15,
@@ -366,11 +366,11 @@ defmodule Seeds do
     {:ok, fighter} = create_class(%{
       name: "Fighter",
       description: "Uses strength and swords to overcome.",
-      regen_health: 2,
+      regen_health_points: 2,
       regen_skill_points: 1,
       each_level_stats: %{
-        health: 5,
-        max_health: 5,
+        health_points: 5,
+        max_health_points: 5,
         skill_points: 2,
         max_skill_points: 2,
         move_points: 3,
@@ -385,11 +385,11 @@ defmodule Seeds do
     {:ok, mage} = create_class(%{
       name: "Mage",
       description: "Uses intelligence and magic to overcome.",
-      regen_health: 1,
+      regen_health_points: 1,
       regen_skill_points: 2,
       each_level_stats: %{
-        health: 3,
-        max_health: 3,
+        health_points: 3,
+        max_health_points: 3,
         skill_points: 5,
         max_skill_points: 5,
         move_points: 3,
@@ -406,8 +406,8 @@ defmodule Seeds do
       name: "Slash",
       description: "Use your weapon to slash at your target",
       points: 1,
-      user_text: "You slash at {target}.",
-      usee_text: "You were slashed at by {user}.",
+      user_text: "You slash at [target].",
+      usee_text: "You were slashed at by [user].",
       command: "slash",
       effects: [
         %{kind: "damage", type: :slashing, amount: 10},
@@ -420,8 +420,8 @@ defmodule Seeds do
       name: "Magic Missile",
       description: "You shoot a bolt of arcane energy out of your hand",
       points: 3,
-      user_text: "You shoot a bolt of arcane energy at {target}.",
-      usee_text: "{user} shoots a bolt of arcane energy at you.",
+      user_text: "You shoot a bolt of arcane energy at [target].",
+      usee_text: "[user] shoots a bolt of arcane energy at you.",
       command: "magic missile",
       effects: [
         %{kind: "damage", type: :arcane, amount: 10},

--- a/test/data/save_test.exs
+++ b/test/data/save_test.exs
@@ -12,10 +12,12 @@ defmodule Data.SaveTest do
       assert save.room_id == 1
     end
 
-    test "loads stats" do
-      {:ok, %Data.Save{stats: stats}} = Data.Save.load(%{"stats" => %{"health" => 50, "strength" => 10, "dexterity" => 10}})
+    test "loads and migrates stats" do
+      save = %{"stats" => %{"health" => 50, "max_health" => 50, "strength" => 10, "dexterity" => 10}}
 
-      assert stats == %{health: 50, strength: 10, dexterity: 10}
+      {:ok, %Data.Save{stats: stats}} = Data.Save.load(save)
+
+      assert %{health_points: 50, max_health_points: 50, strength: 10, dexterity: 10} = stats
     end
 
     test "loads wearing" do

--- a/test/game/command/target_test.exs
+++ b/test/game/command/target_test.exs
@@ -10,7 +10,7 @@ defmodule Game.Command.TargetTest do
 
     room = @room._room()
     |> Map.put(:npcs, [npc])
-    |> Map.put(:players, [%{id: 2, name: "Player", save: %{stats: %{health: 1}}}])
+    |> Map.put(:players, [%{id: 2, name: "Player", save: %{stats: %{health_points: 1}}}])
 
     @room.set_room(room)
     @socket.clear_messages
@@ -39,7 +39,7 @@ defmodule Game.Command.TargetTest do
   test "cannot target another player if health is < 1", %{socket: socket, user: user} do
     room = @room._room()
     |> Map.put(:npcs, [])
-    |> Map.put(:players, [%{id: 2, name: "Player", save: %{stats: %{health: -1}}}])
+    |> Map.put(:players, [%{id: 2, name: "Player", save: %{stats: %{health_points: -1}}}])
     @room.set_room(room)
 
     :ok = Game.Command.Target.run({"player"}, %{socket: socket, user: user, save: %{room_id: 1}})

--- a/test/game/command_test.exs
+++ b/test/game/command_test.exs
@@ -260,7 +260,7 @@ defmodule Game.CommandTest do
   end
 
   test "limit commands to be above 0 hp to perform", %{socket: socket} do
-    save = %{stats: %{health: 0}}
+    save = %{stats: %{health_points: 0}}
     command = %Command{module: Command.Move, args: {:north}}
     :ok = Command.run(command, %{socket: socket, save: save})
     assert @socket.get_echos() == [{socket, "You are passed out and cannot perform this action."}]

--- a/test/game/effect_test.exs
+++ b/test/game/effect_test.exs
@@ -22,10 +22,10 @@ defmodule Game.EffectTest do
   end
 
   describe "applying effects" do
-    test "recover health" do
+    test "recover health points" do
       effect = %{kind: "recover", type: "health", amount: 10}
-      stats = Game.Effect.apply_effect(effect, %{health: 25, max_health: 30})
-      assert stats == %{health: 30, max_health: 30}
+      stats = Game.Effect.apply_effect(effect, %{health_points: 25, max_health_points: 30})
+      assert stats == %{health_points: 30, max_health_points: 30}
     end
 
     test "recover skill points" do

--- a/test/game/experience_test.exs
+++ b/test/game/experience_test.exs
@@ -10,8 +10,8 @@ defmodule Game.ExperienceTest do
     @socket.clear_messages
     class = %{
       each_level_stats: %{
-        health: 5,
-        max_health: 5,
+        health_points: 5,
+        max_health_points: 5,
         strength: 3,
         dexterity: 3,
         intelligence: 3,
@@ -39,8 +39,8 @@ defmodule Game.ExperienceTest do
     state = Experience.apply(state, level: 2, experience_points: 1000)
 
     assert state.save.stats == %{
-      health: 57,
-      max_health: 57,
+      health_points: 57,
+      max_health_points: 57,
       skill_points: 57,
       max_skill_points: 57,
       strength: 15,

--- a/test/game/format_test.exs
+++ b/test/game/format_test.exs
@@ -124,8 +124,8 @@ defmodule Game.FormatTest do
   describe "info formatting" do
     setup do
       stats = %{
-        health: 50,
-        max_health: 55,
+        health_points: 50,
+        max_health_points: 55,
         skill_points: 10,
         max_skill_points: 10,
         move_points: 10,

--- a/test/game/npc/actions_test.exs
+++ b/test/game/npc/actions_test.exs
@@ -12,7 +12,7 @@ defmodule Game.NPC.ActionsTest do
     setup do
       @room.clear_enters()
 
-      npc = %{id: 1, stats: %{health: 10, max_health: 15}}
+      npc = %{id: 1, stats: %{health_points: 10, max_health_points: 15}}
       npc_spawner = %{room_id: 1, spawn_interval: 10}
 
       state = %State{npc: npc, npc_spawner: npc_spawner, room_id: 2}
@@ -21,11 +21,11 @@ defmodule Game.NPC.ActionsTest do
     end
 
     test "respawns the npc", %{state: state, npc: npc} do
-      state = %{state | npc: put_in(npc, [:stats, :health], 0)}
+      state = %{state | npc: put_in(npc, [:stats, :health_points], 0)}
 
       state = Actions.handle_respawn(state)
 
-      assert state.npc.stats.health == 15
+      assert state.npc.stats.health_points == 15
       assert state.room_id == 1
       assert [{1, {:npc, _}, :respawn}] = @room.get_enters()
     end
@@ -117,7 +117,7 @@ defmodule Game.NPC.ActionsTest do
     setup do
       effect = %{id: :id, kind: "damage/over-time", type: :slashing, every: 10, count: 3, amount: 10}
       from = {:user, %{id: 1, name: "Player"}}
-      npc = %{id: 1, name: "NPC", currency: 0, npc_items: [], stats: %{health: 25}}
+      npc = %{id: 1, name: "NPC", currency: 0, npc_items: [], stats: %{health_points: 25}}
       npc_spawner = %{id: 1, spawn_interval: 0}
 
       state = %State{
@@ -137,7 +137,7 @@ defmodule Game.NPC.ActionsTest do
 
       effect_id = effect.id
       assert [{^from, %{id: :id, count: 2}}] = state.continuous_effects
-      assert state.npc.stats.health == 15
+      assert state.npc.stats.health_points == 15
       assert_receive {:continuous_effect, ^effect_id}
     end
 

--- a/test/game/npc/events_test.exs
+++ b/test/game/npc/events_test.exs
@@ -310,7 +310,7 @@ defmodule Game.NPC.EventsTest do
     end
 
     test "does nothing if the NPC has no health", %{state: state, event: event} do
-      stats = %{state.npc.stats | health: 0}
+      stats = %{state.npc.stats | health_points: 0}
       npc = %{state.npc | stats: stats}
       state = %{state | npc: npc}
 

--- a/test/game/npc_test.exs
+++ b/test/game/npc_test.exs
@@ -16,16 +16,16 @@ defmodule Game.NPCTest do
   test "applying effects" do
     effect = %{kind: "damage", type: :slashing, amount: 10}
 
-    state = %State{npc: %{id: 1, name: "NPC", stats: %{health: 25}}}
+    state = %State{npc: %{id: 1, name: "NPC", stats: %{health_points: 25}}}
     {:noreply, state} = NPC.handle_cast({:apply_effects, [effect], {:user, %{id: 2, name: "Player"}}, "description"}, state)
-    assert state.npc.stats.health == 15
+    assert state.npc.stats.health_points == 15
   end
 
   test "applying continuous effects - damage over time" do
     effect = %{kind: "damage/over-time", type: :slashing, every: 10, count: 3, amount: 10}
     from = {:user, %{id: 2, name: "Player"}}
 
-    state = %State{npc: %{id: 1, name: "NPC", stats: %{health: 25}}, continuous_effects: []}
+    state = %State{npc: %{id: 1, name: "NPC", stats: %{health_points: 25}}, continuous_effects: []}
     {:noreply, state} = NPC.handle_cast({:apply_effects, [effect], from, "description"}, state)
     [{^from, effect}] = state.continuous_effects
     assert effect.kind == "damage/over-time"
@@ -38,11 +38,11 @@ defmodule Game.NPCTest do
   test "applying effects - died" do
     effect = %{kind: "damage", type: :slashing, amount: 10}
 
-    npc = %{currency: 0, npc_items: [], id: 1, name: "NPC", stats: %{health: 10}}
+    npc = %{currency: 0, npc_items: [], id: 1, name: "NPC", stats: %{health_points: 10}}
     npc_spawner = %{spawn_interval: 0}
     state = %State{room_id: 1, npc: npc, npc_spawner: npc_spawner}
     {:noreply, state} = NPC.handle_cast({:apply_effects, [effect], {:user, %{id: 2, name: "Player"}}, "description"}, state)
-    assert state.npc.stats.health == 0
+    assert state.npc.stats.health_points == 0
 
     assert [{1, {:npc, _}, :death}] = @room.get_leaves()
     assert [{1, {"character/died", _, _, _}}] = @room.get_notifies()

--- a/test/game/session/effects_test.exs
+++ b/test/game/session/effects_test.exs
@@ -14,7 +14,7 @@ defmodule Game.Session.EffectsTest do
     @room.clear_update_characters()
 
     user = %{id: 2, name: "user", class: class_attributes(%{})}
-    stats = %{health: 25}
+    stats = %{health_points: 25}
     %{state: %State{socket: socket, state: "active", mode: "commands", user: user, save: %{room_id: 1, stats: stats}, is_targeting: MapSet.new()}}
   end
 
@@ -29,7 +29,7 @@ defmodule Game.Session.EffectsTest do
     test "applying effects with continuous effects", %{state: state, effect: effect} do
       state = Effects.handle_continuous_effect(state, effect.id)
 
-      assert state.save.stats.health == 15
+      assert state.save.stats.health_points == 15
       [{:socket, ~s(10 slashing damage is dealt.)}] = @socket.get_echos()
 
       [{_, %{id: :id, count: 2}}] = state.continuous_effects
@@ -43,7 +43,7 @@ defmodule Game.Session.EffectsTest do
       state = %{state | continuous_effects: [{from, effect}]}
 
       state = Effects.handle_continuous_effect(state, :id)
-      assert state.save.stats.health == -1
+      assert state.save.stats.health_points == -1
 
       assert state.continuous_effects == []
     end

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -34,8 +34,8 @@ defmodule TestHelpers do
 
   def base_stats() do
     %{
-      health: 50,
-      max_health: 50,
+      health_points: 50,
+      max_health_points: 50,
       skill_points: 50,
       max_skill_points: 50,
       move_points: 10,
@@ -61,7 +61,7 @@ defmodule TestHelpers do
       wearing: %{},
       wielding: %{},
       config: %{hints: true, prompt: "%h/%Hhp"},
-      version: 6,
+      version: 7,
     }
   end
 
@@ -181,8 +181,8 @@ defmodule TestHelpers do
       name: "Human",
       description: "A human",
       starting_stats: %{
-        health: 25,
-        max_health: 25,
+        health_points: 25,
+        max_health_points: 25,
         strength: 10,
         dexterity: 10,
         intelligence: 10,
@@ -205,11 +205,11 @@ defmodule TestHelpers do
     Map.merge(%{
       name: "Fighter",
       description: "A fighter",
-      regen_health: 1,
+      regen_health_points: 1,
       regen_skill_points: 1,
       each_level_stats: %{
-        health: 5,
-        max_health: 5,
+        health_points: 5,
+        max_health_points: 5,
         strength: 1,
         dexterity: 1,
         intelligence: 1,
@@ -269,8 +269,8 @@ defmodule TestHelpers do
       status_line: "{name} is here.",
       description: "{status_line}",
       stats: %{
-        health: 25,
-        max_health: 25,
+        health_points: 25,
+        max_health_points: 25,
         skill_points: 10,
         max_skill_points: 10,
         strength: 13,

--- a/test/web/class_test.exs
+++ b/test/web/class_test.exs
@@ -8,7 +8,7 @@ defmodule Web.ClassTest do
     params = %{
       "name" => "Fighter",
       "description" => "A fighter",
-      "regen_health" => 1,
+      "regen_health_points" => 1,
       "regen_skill_points" => 1,
       "each_level_stats" => base_stats() |> Poison.encode!(),
     }
@@ -16,7 +16,7 @@ defmodule Web.ClassTest do
     {:ok, class} = Class.create(params)
 
     assert class.name == "Fighter"
-    assert class.each_level_stats.health == 50
+    assert class.each_level_stats.health_points == 50
   end
 
   test "updating a class" do

--- a/test/web/controller/admin/class_controller_test.exs
+++ b/test/web/controller/admin/class_controller_test.exs
@@ -5,7 +5,7 @@ defmodule Web.Admin.ClassControllerTest do
     params = %{
       "name" => "Fighter",
       "description" => "A fighter",
-      "regen_health" => 1,
+      "regen_health_points" => 1,
       "regen_skill_points" => 1,
       "each_level_stats" => base_stats() |> Poison.encode!(),
     }

--- a/test/web/npc_test.exs
+++ b/test/web/npc_test.exs
@@ -19,8 +19,8 @@ defmodule Web.NPCTest do
         %{"key" => "start", "message" => "Hi"},
       ] |> Poison.encode!(),
       "stats" => %{
-        health: 25,
-        max_health: 25,
+        health_points: 25,
+        max_health_points: 25,
         strength: 10,
         dexterity: 10,
         intelligence: 10,

--- a/test/web/race_test.exs
+++ b/test/web/race_test.exs
@@ -9,8 +9,8 @@ defmodule Web.RaceTest do
       "name" => "Human",
       "description" => "A human",
       "starting_stats" => %{
-        health: 25,
-        max_health: 25,
+        health_points: 25,
+        max_health_points: 25,
         strength: 10,
         dexterity: 10,
         intelligence: 10,
@@ -25,7 +25,7 @@ defmodule Web.RaceTest do
     {:ok, race} = Race.create(params)
 
     assert race.name == "Human"
-    assert race.starting_stats.health == 25
+    assert race.starting_stats.health_points == 25
   end
 
   test "updating a race" do


### PR DESCRIPTION
- Make point stats be consistent
- Migrate old health data into the new format when loading saves
- Migrate when defaulting stats
- Class regen fields use `_points`

Old production data _should_ migrate cleanly into this new format,
registrations still work with old starting save data.