### PR TITLE
Basic NPC status

### DIFF
--- a/docs/admin/events.md
+++ b/docs/admin/events.md
@@ -111,6 +111,43 @@ The move action takes a `max_distance` that the NPC will stray from their origin
 
 The emote action takes a `message` that the NPC will emote into the room. `chance` is the percent chance that the NPC will do this action on each tick. `wait` is optional and will enforce a delay of `wait` seconds since the last emote. Multiple emote ticks update the same timestamp of when an emote occured.
 
+#### Status change
+
+You can also include a `status` key to change the status of the NPC during the emote.
+
+```
+{
+  "type": "tick",
+  "action": {
+    "type": "emote",
+    "message": "moves about the store",
+    "chance": 50,
+    "wait": 15
+    "status": {
+      "line": "[name] is moving around the store",
+      "listen": "[name] is whistling"
+    }
+  }
+}
+```
+
+You can also reset the status to the NPC's default:
+
+```
+{
+  "type": "tick",
+  "action": {
+    "type": "emote",
+    "message": "pauses for a second",
+    "chance": 50,
+    "wait": 15
+    "status": {
+      "reset": true
+    }
+  }
+}
+```
+
 ### say
 
 ```

--- a/lib/data/npc.ex
+++ b/lib/data/npc.ex
@@ -16,6 +16,7 @@ defmodule Data.NPC do
     :name,
     :tags,
     :status_line,
+    :status_listen,
     :description,
     :experience_points,
     :currency,

--- a/lib/game/npc.ex
+++ b/lib/game/npc.ex
@@ -15,6 +15,7 @@ defmodule Game.NPC do
   alias Game.NPC.Conversation
   alias Game.NPC.Events
   alias Game.NPC.Repo, as: NPCRepo
+  alias Game.NPC.Status
   alias Game.Zone
 
   defmacro __using__(_opts) do
@@ -34,6 +35,7 @@ defmodule Game.NPC do
       :room_id,
       :target,
       :last_controlled_at,
+      :status,
       combat: false,
       tick_events: [],
       conversations: %{},
@@ -169,6 +171,7 @@ defmodule Game.NPC do
 
     npc = customize_npc(npc_spawner, npc_spawner.npc)
     npc = %{npc | stats: Stats.default(npc.stats)}
+    status = %Status{key: "start", line: npc.status_line, listen: npc.status_listen}
 
     npc_spawner.zone_id |> Zone.npc_online(npc)
 
@@ -178,6 +181,7 @@ defmodule Game.NPC do
       state
       |> Map.put(:npc_spawner, npc_spawner)
       |> Map.put(:npc, npc)
+      |> Map.put(:status, status)
       |> Map.put(:room_id, npc_spawner.room_id)
 
     GenServer.cast(self(), :enter)

--- a/lib/game/npc/actions.ex
+++ b/lib/game/npc/actions.ex
@@ -17,6 +17,7 @@ defmodule Game.NPC.Actions do
   alias Game.Effect
   alias Game.Items
   alias Game.NPC.Events
+  alias Game.NPC.Status
 
   @doc """
   Clean up conversation state, after 5 minutes remove the state of the user
@@ -34,9 +35,10 @@ defmodule Game.NPC.Actions do
 
   def handle_respawn(state = %{npc: npc, npc_spawner: npc_spawner}) do
     npc = %{npc | stats: %{npc.stats | health_points: npc.stats.max_health_points}}
+    status = %Status{key: "start", line: npc.status_line, listen: npc.status_listen}
     npc_spawner.room_id |> @room.enter({:npc, npc}, :respawn)
     Events.broadcast(npc, "character/respawned")
-    %{state | npc: npc, room_id: npc_spawner.room_id}
+    %{state | npc: npc, status: status, room_id: npc_spawner.room_id}
   end
 
   @doc """

--- a/lib/game/npc/status.ex
+++ b/lib/game/npc/status.ex
@@ -1,0 +1,12 @@
+defmodule Game.NPC.Status do
+  @moduledoc """
+  Structure for NPC status
+  """
+
+  @doc """
+  - `key`: Key for the status. The starting status is "start"
+  - `line`: text used for the status line, showed to players in the room look
+  - `listen`: text used for when a player listens to the room they're in
+  """
+  defstruct [:key, :line, :listen]
+end

--- a/test/data/event_test.exs
+++ b/test/data/event_test.exs
@@ -30,4 +30,30 @@ defmodule Data.EventTest do
       },
     }
   end
+
+  describe "validates the status attribute" do
+    test "requires the key" do
+      assert Event.valid_status?(%{key: "status"})
+      refute Event.valid_status?(%{line: "line text"})
+    end
+
+    test "can include line and/or listen and includes a key" do
+      assert Event.valid_status?(%{key: "status", listen: "listen text"})
+      assert Event.valid_status?(%{key: "status", line: "line text"})
+      assert Event.valid_status?(%{key: "status", line: "line text", listen: "listen text"})
+    end
+
+    test "keys must be strings" do
+      refute Event.valid_status?(%{key: "status", listen: false})
+    end
+
+    test "can include reset" do
+      assert Event.valid_status?(%{reset: true})
+      refute Event.valid_status?(%{reset: false})
+    end
+
+    test "cannot include reset with other attributes" do
+      refute Event.valid_status?(%{key: "status", line: "line text", listen: "listen text", reset: true})
+    end
+  end
 end

--- a/test/game/npc/actions_test.exs
+++ b/test/game/npc/actions_test.exs
@@ -28,7 +28,12 @@ defmodule Game.NPC.ActionsTest do
     setup do
       @room.clear_enters()
 
-      npc = %{id: 1, stats: %{health_points: 10, max_health_points: 15}}
+      npc = %{
+        id: 1,
+        stats: %{health_points: 10, max_health_points: 15},
+        status_line: "[name] is here",
+        status_listen: nil
+      }
       npc_spawner = %{room_id: 1, spawn_interval: 10}
 
       state = %State{npc: npc, npc_spawner: npc_spawner, room_id: 2}


### PR DESCRIPTION
This will be the start of a small NPC status engine. It will start as the NPC being able to change it's listen and status line. I am requiring a key to be set so emotes and other actions can be gated behind a specific status.