### PR TITLE
Continuous stat boosts

### DIFF
--- a/docs/admin/effects.md
+++ b/docs/admin/effects.md
@@ -62,3 +62,16 @@ The amount of damage a usee will be healed for. This is boosted by wisdom.
 ```
 
 This effect boosts the user's stats before any other effects are calulated.
+
+## stats/boost
+
+```
+{
+  'kind': 'stats/boost',
+  'field': 'dexterity',
+  'amount': 10,
+  'duration': 1500
+}
+```
+
+This effect boosts the target's stats for the `duration` amount in milliseconds.

--- a/lib/data/effect.ex
+++ b/lib/data/effect.ex
@@ -384,6 +384,23 @@ defmodule Data.Effect do
   def continuous?(_), do: false
 
   @doc """
+  Check if an effect is continuous and should apply to every effect coming in
+
+    iex> Data.Effect.applies_to_every_effect?(%{kind: "stats/boost"})
+    true
+
+    iex> Data.Effect.applies_to_every_effect?(%{kind: "damage/over-time"})
+    false
+
+    iex> Data.Effect.continuous?(%{kind: "damage"})
+    false
+  """
+  @spec applies_to_every_effect?(Effect.t()) :: boolean()
+  def applies_to_every_effect?(effect)
+  def applies_to_every_effect?(%{kind: "stats/boost"}), do: true
+  def applies_to_every_effect?(_), do: false
+
+  @doc """
   Instantiate an effect by giving it an ID to track, for future callbacks
   """
   @spec instantiate(Effect.t()) :: boolean()

--- a/lib/game/character/effects.ex
+++ b/lib/game/character/effects.ex
@@ -39,6 +39,21 @@ defmodule Game.Character.Effects do
   end
 
   @doc """
+  Apply a continuous effect to a character's stats
+  """
+  @spec apply_continuous_effect(Stats.t(), State.t(), Effect.t()) :: {Stats.t(), [Effect.t()]}
+  def apply_continuous_effect(stats, state, effect) do
+    effects =
+      [effect]
+      |> Effect.add_current_continuous_effects(state)
+      |> Effect.adjust_effects(stats)
+
+    stats = Effect.apply(effects, stats)
+
+    {stats, effects}
+  end
+
+  @doc """
   Clear a continuous effect after its duration is over
   """
   @spec clear_continuous_effect(State.t(), String.t()) :: State.t()

--- a/lib/game/character/effects.ex
+++ b/lib/game/character/effects.ex
@@ -18,11 +18,8 @@ defmodule Game.Character.Effects do
   def apply_effects(character, stats, state, effects, from) do
     continuous_effects = effects |> Effect.continuous_effects(from)
 
-    effects =
-      effects
-      |> Effect.add_current_continuous_effects(state)
-      |> Effect.adjust_effects(stats)
-
+    stats = stats |> Effect.calculate_stats_from_continuous_effects(state)
+    effects = effects |> Effect.adjust_effects(stats)
     stats = effects |> Effect.apply(stats)
 
     from |> Character.effects_applied(effects, character)
@@ -43,13 +40,9 @@ defmodule Game.Character.Effects do
   """
   @spec apply_continuous_effect(Stats.t(), State.t(), Effect.t()) :: {Stats.t(), [Effect.t()]}
   def apply_continuous_effect(stats, state, effect) do
-    effects =
-      [effect]
-      |> Effect.add_current_continuous_effects(state)
-      |> Effect.adjust_effects(stats)
-
+    stats = stats |> Effect.calculate_stats_from_continuous_effects(state)
+    effects = [effect] |> Effect.adjust_effects(stats)
     stats = Effect.apply(effects, stats)
-
     {stats, effects}
   end
 

--- a/lib/game/character/effects.ex
+++ b/lib/game/character/effects.ex
@@ -1,0 +1,52 @@
+defmodule Game.Character.Effects do
+  @moduledoc """
+  Common effects functions for characters
+  """
+
+  require Logger
+
+  alias Data.Stat
+  alias Game.Character
+  alias Game.Character.State
+  alias Game.Effect
+
+  @doc """
+  Common character effect application
+  """
+  @spec apply_effects(Character.t(), Stats.t(), State.t(), [Effect.t()], Character.t()) ::
+    {Stat.t(), [Effect.t()], [Effect.continuous_effect()]}
+  def apply_effects(character, stats, state, effects, from) do
+    continuous_effects = effects |> Effect.continuous_effects(from)
+
+    effects =
+      effects
+      |> Effect.add_current_continuous_effects(state)
+      |> Effect.adjust_effects(stats)
+
+    stats = effects |> Effect.apply(stats)
+
+    from |> Character.effects_applied(effects, character)
+
+    Enum.each(continuous_effects, fn {_from, effect} ->
+      Logger.debug(fn ->
+        "Maybe delaying effect (#{effect.id})"
+      end, type: :character)
+
+      effect |> Effect.maybe_tick_effect(self())
+    end)
+
+    {stats, effects, continuous_effects}
+  end
+
+  @doc """
+  Clear a continuous effect after its duration is over
+  """
+  @spec clear_continuous_effect(State.t(), String.t()) :: State.t()
+  def clear_continuous_effect(state, effect_id) do
+    continuous_effects = Enum.reject(state.continuous_effects, fn {_from, effect} ->
+      effect.id == effect_id
+    end)
+
+    %{state | continuous_effects: continuous_effects}
+  end
+end

--- a/lib/game/character/helpers.ex
+++ b/lib/game/character/helpers.ex
@@ -25,8 +25,11 @@ defmodule Game.Character.Helpers do
     maybe_send_continuous_effect(effect)
 
     case effect.count do
-      0 -> %{state | continuous_effects: continuous_effects}
-      _ -> %{state | continuous_effects: [{from, effect} | continuous_effects]}
+      0 ->
+        %{state | continuous_effects: continuous_effects}
+
+      _ ->
+        %{state | continuous_effects: [{from, effect} | continuous_effects]}
     end
   end
 

--- a/lib/game/character/state.ex
+++ b/lib/game/character/state.ex
@@ -1,0 +1,12 @@
+defmodule Game.Character.State do
+  @moduledoc """
+  A common type for character state
+  """
+
+  alias Data.Effect
+  alias Game.Character
+
+  @type t :: %{
+    continuous_effects: [{Character.t(), Effect.t()}]
+  }
+end

--- a/lib/game/command/skills.ex
+++ b/lib/game/command/skills.ex
@@ -226,11 +226,12 @@ defmodule Game.Command.Skills do
 
         player_effects = save |> Item.effects_on_player()
 
-        effects =
-          (player_effects ++ skill.effects)
-          |> Skill.filter_effects(skill)
+        effects = Skill.filter_effects(player_effects ++ skill.effects, skill)
 
-        effects = stats |> Effect.calculate(effects)
+        effects =
+          stats
+          |> Effect.calculate_stats_from_continuous_effects(state)
+          |> Effect.calculate(effects)
 
         Character.apply_effects(
           target,

--- a/lib/game/effect.ex
+++ b/lib/game/effect.ex
@@ -279,7 +279,11 @@ defmodule Game.Effect do
   """
   @spec add_current_continuous_effects([Effect.t()], map()) :: [Effect.t()]
   def add_current_continuous_effects(effects, state) do
-    continuous_effects = Enum.map(state.continuous_effects, &(elem(&1, 1)))
+    continuous_effects =
+      state.continuous_effects
+      |> Enum.map(&(elem(&1, 1)))
+      |> Enum.filter(&Effect.applies_to_every_effect?/1)
+
     effects ++ continuous_effects
   end
 

--- a/lib/game/effect.ex
+++ b/lib/game/effect.ex
@@ -9,6 +9,8 @@ defmodule Game.Effect do
 
   @random_damage Application.get_env(:ex_venture, :game)[:random_damage]
 
+  @type continuous_effect :: {Character.t(), Effec.t()}
+
   @doc """
   Calculate effects based on the user
 

--- a/lib/game/effect.ex
+++ b/lib/game/effect.ex
@@ -79,8 +79,7 @@ defmodule Game.Effect do
         stats |> Map.put(effect.field, stats[effect.field] + effect.amount)
 
       "subtract" ->
-        value = max(stats[effect.field] - effect.amount, 0)
-        stats |> Map.put(effect.field, value)
+        stats |> Map.put(effect.field, stats[effect.field] - effect.amount)
 
       "multiply" ->
         stats |> Map.put(effect.field, stats[effect.field] * effect.amount)
@@ -100,7 +99,7 @@ defmodule Game.Effect do
         stat = Map.get(stats, damage_type.stat_modifier)
         random_swing = Enum.random(@random_damage)
         modifier = 1 + stat / damage_type.boost_ratio + random_swing / 100
-        modified_amount = round(Float.ceil(effect.amount * modifier))
+        modified_amount = max(round(Float.ceil(effect.amount * modifier)), 0)
         effect |> Map.put(:amount, modified_amount)
 
       _ ->

--- a/lib/game/npc.ex
+++ b/lib/game/npc.ex
@@ -339,6 +339,11 @@ defmodule Game.NPC do
     {:noreply, state}
   end
 
+  def handle_info({:continuous_effect, :clear, effect_id}, state) do
+    state = Actions.clear_continuous_effect(state, effect_id)
+    {:noreply, state}
+  end
+
   def handle_info({:channel, {:tell, {:user, user}, message}}, state) do
     state = Conversation.recv(state, user, message.message)
     schedule_cleaning_conversations()

--- a/lib/game/npc.ex
+++ b/lib/game/npc.ex
@@ -11,6 +11,7 @@ defmodule Game.NPC do
   alias Data.NPCSpawner
   alias Data.Stats
   alias Game.Channel
+  alias Game.Character.Effects
   alias Game.NPC.Actions
   alias Game.NPC.Conversation
   alias Game.NPC.Events
@@ -340,7 +341,7 @@ defmodule Game.NPC do
   end
 
   def handle_info({:continuous_effect, :clear, effect_id}, state) do
-    state = Actions.clear_continuous_effect(state, effect_id)
+    state = Effects.clear_continuous_effect(state, effect_id)
     {:noreply, state}
   end
 

--- a/lib/game/npc/actions.ex
+++ b/lib/game/npc/actions.ex
@@ -180,8 +180,8 @@ defmodule Game.NPC.Actions do
   """
   @spec apply_continuous_effect(State.t(), {Character.t(), Effect.t()}) :: State.t()
   def apply_continuous_effect(state = %{npc: npc}, {from, effect}) do
-    effects = [effect] |> Effect.adjust_effects(npc.stats)
-    stats = effects |> Effect.apply(npc.stats)
+    {stats, _effects} = Effects.apply_continuous_effect(npc.stats, state, effect)
+
     state = stats |> maybe_died(state, from)
     npc = %{npc | stats: stats}
     state = %{state | npc: npc}

--- a/lib/game/npc/events.ex
+++ b/lib/game/npc/events.ex
@@ -229,7 +229,11 @@ defmodule Game.NPC.Events do
 
   defp perform_combat_action(event, target, npc, state) do
     action = event.action
-    effects = npc.stats |> Effect.calculate(action.effects)
+
+    effects =
+      npc.stats
+      |> Effect.calculate_stats_from_continuous_effects(state)
+      |> Effect.calculate(action.effects)
 
     Character.apply_effects(
       target,

--- a/lib/game/session/effects.ex
+++ b/lib/game/session/effects.ex
@@ -119,8 +119,7 @@ defmodule Game.Session.Effects do
   def apply_continuous_effect(state, {from, effect}) do
     %{socket: socket, user: user, save: save} = state
 
-    effects = [effect] |> Effect.adjust_effects(save.stats)
-    stats = effects |> Effect.apply(save.stats)
+    {stats, effects} = Character.Effects.apply_continuous_effect(save.stats, state, effect)
 
     save = Map.put(save, :stats, stats)
     user = Map.put(user, :save, save)

--- a/lib/game/session/effects.ex
+++ b/lib/game/session/effects.ex
@@ -26,9 +26,8 @@ defmodule Game.Session.Effects do
   def apply(effects, from, description, state) do
     %{user: user, save: save} = state
 
-    effects = effects |> Effect.adjust_effects(save.stats)
-    continuous_effects = effects |> Effect.continuous_effects(from)
-    stats = effects |> Effect.apply(save.stats)
+    {stats, effects, continuous_effects} =
+      Character.Effects.apply_effects({:user, user}, save.stats, state, effects, from)
 
     save = Map.put(save, :stats, stats)
     user = Map.put(user, :save, save)
@@ -36,16 +35,7 @@ defmodule Game.Session.Effects do
     state = %{state | user: user, save: save}
 
     user |> echo_effects(from, description, effects)
-    from |> Character.effects_applied(effects, {:user, user})
     user |> maybe_died(state, from)
-
-    Enum.each(continuous_effects, fn {_from, effect} ->
-      Logger.debug(fn ->
-        "Maybe delaying effect (#{effect.id})"
-      end, type: :player)
-
-      effect |> Effect.maybe_tick_effect(self())
-    end)
 
     case is_alive?(state.save) do
       true ->
@@ -120,18 +110,6 @@ defmodule Game.Session.Effects do
       {:error, :not_found} ->
         state
     end
-  end
-
-  @doc """
-  Clear a continuous effect after its duration is over
-  """
-  @spec clear_continuous_effect(State.t(), String.t()) :: State.t()
-  def clear_continuous_effect(state, effect_id) do
-    continuous_effects = Enum.reject(state.continuous_effects, fn {_from, effect} ->
-      effect.id == effect_id
-    end)
-
-    %{state | continuous_effects: continuous_effects}
   end
 
   @doc """

--- a/lib/game/session/process.ex
+++ b/lib/game/session/process.ex
@@ -12,6 +12,7 @@ defmodule Game.Session.Process do
   require Logger
 
   alias Game.Account
+  alias Game.Character
   alias Game.Command.Move
   alias Game.Command.Pager
   alias Game.Format
@@ -297,7 +298,7 @@ defmodule Game.Session.Process do
       "Clearing effect (#{effect_id})"
     end, type: :player)
 
-    state = Effects.clear_continuous_effect(state, effect_id)
+    state = Character.Effects.clear_continuous_effect(state, effect_id)
     {:noreply, state}
   end
 

--- a/lib/game/session/process.ex
+++ b/lib/game/session/process.ex
@@ -288,7 +288,10 @@ defmodule Game.Session.Process do
   end
 
   def handle_info({:continuous_effect, effect_id}, state) do
-    Logger.debug(fn -> "Processing effect (#{effect_id})" end, type: :player)
+    Logger.debug(fn ->
+      "Processing effect (#{effect_id})"
+    end, type: :player)
+
     state = Effects.handle_continuous_effect(state, effect_id)
     {:noreply, state}
   end

--- a/lib/game/session/process.ex
+++ b/lib/game/session/process.ex
@@ -292,6 +292,15 @@ defmodule Game.Session.Process do
     {:noreply, state}
   end
 
+  def handle_info({:continuous_effect, :clear, effect_id}, state) do
+    Logger.debug(fn ->
+      "Clearing effect (#{effect_id})"
+    end, type: :player)
+
+    state = Effects.clear_continuous_effect(state, effect_id)
+    {:noreply, state}
+  end
+
   def handle_info({:skill, :ready, skill}, state) do
     state.socket |> @socket.echo("#{Format.skill_name(skill)} is ready.")
     {:noreply, state}

--- a/lib/web/templates/admin/shared/_effects.html.eex
+++ b/lib/web/templates/admin/shared/_effects.html.eex
@@ -5,7 +5,8 @@ $(function() {
     "damage/type": <%= Effect.starting_effect("damage/type") |> encode_json() %>,
     "damage/over-time": <%= Effect.starting_effect("damage/over-time") |> encode_json() %>,
     "recover": <%= Effect.starting_effect("recover") |> encode_json() %>,
-    "stats": <%= Effect.starting_effect("stats") |> encode_json() %>
+    "stats": <%= Effect.starting_effect("stats") |> encode_json() %>,
+    "stats/boost": <%= Effect.starting_effect("stats/boost") |> encode_json() %>
   };
 
   if ($("#<%= @id %>").val() == "") {
@@ -29,6 +30,7 @@ $(function() {
   <%= link("Add 'damage/over-time'", to: "#", class: "btn btn-default add-effect", data: [type: "damage/over-time"]) %>
   <%= link("Add 'recover'", to: "#", class: "btn btn-default add-effect", data: [type: "recover"]) %>
   <%= link("Add 'stats'", to: "#", class: "btn btn-default add-effect", data: [type: "stats"]) %>
+  <%= link("Add 'stats/boost'", to: "#", class: "btn btn-default add-effect", data: [type: "stats/boost"]) %>
 </span>
 <span class="help-block">
   <%= link("View effect documentation", to: "https://exventure.org/admin/effects/", target: "_blank", class: "btn btn-default") %>

--- a/test/data/effect_test.exs
+++ b/test/data/effect_test.exs
@@ -9,4 +9,16 @@ defmodule Data.EffectTest do
     effect = Effect.instantiate(effect)
     assert effect.id
   end
+
+  describe "continious stats" do
+    test "load them" do
+      {:ok, stat_boost} = Effect.load(%{"kind" => "stats/boost", "field" => "dexterity", "amount" => 10, "duration" => 1000})
+      assert stat_boost == %{kind: "stats/boost", field: :dexterity, amount: 10, duration: 1000}
+    end
+
+    test "validate them" do
+      stat_boost = %{kind: "stats/boost", field: :dexterity, amount: 10, duration: 1000}
+      assert Effect.valid?(stat_boost)
+    end
+  end
 end

--- a/test/data/effect_test.exs
+++ b/test/data/effect_test.exs
@@ -12,13 +12,53 @@ defmodule Data.EffectTest do
 
   describe "continious stats" do
     test "load them" do
-      {:ok, stat_boost} = Effect.load(%{"kind" => "stats/boost", "field" => "dexterity", "amount" => 10, "duration" => 1000})
-      assert stat_boost == %{kind: "stats/boost", field: :dexterity, amount: 10, duration: 1000}
+      stats_boost = %{
+        "kind" => "stats/boost",
+        "field" => "dexterity",
+        "amount" => 10,
+        "mode" => "add",
+        "duration" => 1000
+      }
+
+      {:ok, stat_boost} = Effect.load(stats_boost)
+
+      assert stat_boost == %{
+        kind: "stats/boost",
+        field: :dexterity,
+        amount: 10,
+        mode: "add",
+        duration: 1000
+      }
     end
 
     test "validate them" do
-      stat_boost = %{kind: "stats/boost", field: :dexterity, amount: 10, duration: 1000}
+      stat_boost = %{
+        kind: "stats/boost",
+        field: :dexterity,
+        amount: 10,
+        mode: "add",
+        duration: 1000
+      }
+
       assert Effect.valid?(stat_boost)
+    end
+
+    test "validate the mode" do
+      stat_boost = %{
+        kind: "stats/boost",
+        field: :dexterity,
+        amount: 10,
+        mode: "add",
+        duration: 1000
+      }
+
+      assert Effect.valid_stats_boost?(stat_boost)
+
+      assert Effect.valid_stats_boost?(%{stat_boost | mode: "subtract"})
+      assert Effect.valid_stats_boost?(%{stat_boost | mode: "multiply"})
+      assert Effect.valid_stats_boost?(%{stat_boost | mode: "divide"})
+
+      refute Effect.valid_stats_boost?(%{stat_boost | mode: "remove"})
     end
   end
 end

--- a/test/data/item_test.exs
+++ b/test/data/item_test.exs
@@ -112,7 +112,7 @@ defmodule Data.ItemTest do
       changeset = %Item{} |> Item.changeset(%{type: "weapon", effects: [%{kind: "damage", amount: 10, type: "slashing"}]})
       refute changeset.errors[:effects]
 
-      changeset = %Item{} |> Item.changeset(%{type: "weapon", effects: [%{kind: "stats", field: :strength, amount: 10}]})
+      changeset = %Item{} |> Item.changeset(%{type: "weapon", effects: [%{kind: "stats", mode: "add", field: :strength, amount: 10}]})
       refute changeset.errors[:effects]
 
       changeset = %Item{} |> Item.changeset(%{type: "weapon", effects: [%{kind: "damage/type", types: ["slashing"]}]})
@@ -123,7 +123,7 @@ defmodule Data.ItemTest do
     end
 
     test "must be a stats type for armor" do
-      changeset = %Item{} |> Item.changeset(%{type: "armor", effects: [%{kind: "stats", field: :strength, amount: 10}]})
+      changeset = %Item{} |> Item.changeset(%{type: "armor", effects: [%{kind: "stats", mode: "add", field: :strength, amount: 10}]})
       refute changeset.errors[:effects]
 
       changeset = %Item{} |> Item.changeset(%{type: "armor", effects: [%{kind: "damage", amount: 10, type: "slashing"}]})

--- a/test/game/command/info_test.exs
+++ b/test/game/command/info_test.exs
@@ -8,7 +8,7 @@ defmodule Game.Command.InfoTest do
 
   describe "viewing your information" do
     setup do
-      armor = %{id: 1, effects: [%{kind: "stats", field: :strength, amount: 10}]}
+      armor = %{id: 1, effects: [%{kind: "stats", mode: "add", field: :strength, amount: 10}]}
       start_and_clear_items()
       insert_item(armor)
 

--- a/test/game/effect_test.exs
+++ b/test/game/effect_test.exs
@@ -53,6 +53,22 @@ defmodule Game.EffectTest do
     assert calculated_effects == [%{kind: "damage", amount: 8, type: "slashing"}, %{kind: "damage", amount: 15, type: "bludgeoning"}]
   end
 
+  describe "calculating damage" do
+    test "simple damage" do
+      slashing_effect = %{kind: "damage", type: "slashing", amount: 10}
+
+      calculated_effect = Effect.calculate_damage(slashing_effect, %{strength: -10})
+      assert calculated_effect == %{kind: "damage", amount: 5, type: "slashing"}
+    end
+
+    test "stat is reduced enough to hit minimum damage" do
+      slashing_effect = %{kind: "damage", type: "slashing", amount: 10}
+
+      calculated_effect = Effect.calculate_damage(slashing_effect, %{strength: -30})
+      assert calculated_effect == %{kind: "damage", amount: 0, type: "slashing"}
+    end
+  end
+
   describe "calculating stats" do
     test "normal stats" do
       stats = %{strength: 10}
@@ -148,12 +164,6 @@ defmodule Game.EffectTest do
       effect = %{field: :strength, mode: "subtract", amount: 1}
 
       assert Effect.process_stats(effect, stats) == %{strength: 9}
-    end
-
-    test "subtraction - sticks to >= 0", %{stats: stats} do
-      effect = %{field: :strength, mode: "subtract", amount: 15}
-
-      assert Effect.process_stats(effect, stats) == %{strength: 0}
     end
 
     test "multiplication", %{stats: stats} do


### PR DESCRIPTION
- [x] Save them as an effect
- [x] Apply them to the character before using an action
- [x] Clear them after their duration
- [x] stats boost mode
- [x] NPC and Player effects handling looks awfully similar