### PR TITLE
Add require_target to skills

### DIFF
--- a/lib/data/skill.ex
+++ b/lib/data/skill.ex
@@ -24,6 +24,7 @@ defmodule Data.Skill do
     field(:effects, {:array, Effect})
     field(:tags, {:array, :string}, default: [])
     field(:is_global, :boolean, default: false)
+    field(:require_target, :boolean, default: false)
 
     has_many(:class_skills, ClassSkill)
     has_many(:classes, through: [:class_skills, :class])
@@ -45,7 +46,8 @@ defmodule Data.Skill do
       :whitelist_effects,
       :effects,
       :tags,
-      :is_global
+      :is_global,
+      :require_target
     ])
     |> validate_required([
       :name,
@@ -59,7 +61,8 @@ defmodule Data.Skill do
       :whitelist_effects,
       :effects,
       :tags,
-      :is_global
+      :is_global,
+      :require_target
     ])
     |> validate_effects()
     |> validate_whitelist()

--- a/lib/game/command/target.ex
+++ b/lib/game/command/target.ex
@@ -144,8 +144,11 @@ defmodule Game.Command.Target do
     case find_target_in_list(users, name) do
       nil ->
         case find_target_in_list(npcs, name) do
-          nil -> nil
-          npc -> {:npc, npc}
+          nil ->
+            nil
+
+          npc ->
+            {:npc, npc}
         end
 
       user ->

--- a/lib/game/npc/events.ex
+++ b/lib/game/npc/events.ex
@@ -212,14 +212,14 @@ defmodule Game.NPC.Events do
     room = @room.look(room_id)
 
     case find_target(room, target) do
-      nil ->
-        {:update, %{state | target: nil, combat: false}}
-
-      target ->
+      {:ok, target} ->
         npc.events
         |> Enum.filter(&(&1.type == "combat/tick"))
         |> Combat.weighted_event()
         |> perform_combat_action(target, npc, state)
+
+      {:error, :not_found} ->
+        {:update, %{state | target: nil, combat: false}}
     end
   end
 

--- a/lib/web/templates/admin/skill/_form.html.eex
+++ b/lib/web/templates/admin/skill/_form.html.eex
@@ -24,6 +24,16 @@
         </div>
       </div>
 
+      <div class="form-group">
+        <div class="col-md-8 col-md-offset-4">
+          <%= label f, :require_target do %>
+            <%= checkbox f, :require_target %> Require a target?
+          <% end %>
+          <%= error_tag f, :is_global %>
+          <span class="help-block"><%= Help.get("skill.require_target") %></span>
+        </div>
+      </div>
+
       <h4>Usage</h4>
       <hr />
 

--- a/lib/web/templates/admin/skill/show.html.eex
+++ b/lib/web/templates/admin/skill/show.html.eex
@@ -75,6 +75,10 @@
                 <td><span class="label label-default"><%= @skill.is_global %></span></td>
               </tr>
               <tr>
+                <th>Require target?</th>
+                <td><span class="label label-default"><%= @skill.require_target %></span></td>
+              </tr>
+              <tr>
                 <th>
                   White Listed Effect Types
                   <%= SharedView.help_tooltip("skill.whitelist_effects") %>

--- a/priv/help/web.help
+++ b/priv/help/web.help
@@ -109,6 +109,9 @@ room_feature.short_description:
 skill.cooldown_time:
   Milliseconds the player must wait before the skill can be used again.
 
+skill.require_target:
+  If required, the target defaults to the character. For things like `cure wounds` which should heal the using character unless a target is provided.
+
 skill.user_text:
   Text the user of the skill will see. Available template variables: `[target]`, `[user]`
 

--- a/priv/repo/migrations/20180522004951_add_target_self_first_to_skills.exs
+++ b/priv/repo/migrations/20180522004951_add_target_self_first_to_skills.exs
@@ -1,0 +1,9 @@
+defmodule Data.Repo.Migrations.AddTargetSelfFirstToSkills do
+  use Ecto.Migration
+
+  def change do
+    alter table(:skills) do
+      add :require_target, :boolean, default: false, null: false
+    end
+  end
+end


### PR DESCRIPTION
This allows spells such as `cure wounds` to target yourself in a fight
_without_ sending to your target or requiring `cure wounds playername`.