### PR TITLE
Allow movement in diagonal directions

### DIFF
--- a/lib/data/exit.ex
+++ b/lib/data/exit.ex
@@ -172,68 +172,44 @@ defmodule Data.Exit do
   From a direction find the opposite direction's id
 
       iex> Data.Exit.opposite("north")
-      :south
-      iex> Data.Exit.opposite(:north)
-      :south
+      "south"
 
       iex> Data.Exit.opposite("east")
-      :west
-      iex> Data.Exit.opposite(:east)
-      :west
+      "west"
 
       iex> Data.Exit.opposite("south")
-      :north
-      iex> Data.Exit.opposite(:south)
-      :north
+      "north"
 
       iex> Data.Exit.opposite("west")
-      :east
-      iex> Data.Exit.opposite(:west)
-      :east
+      "east"
 
       iex> Data.Exit.opposite("up")
-      :down
-      iex> Data.Exit.opposite(:up)
-      :down
+      "down"
 
       iex> Data.Exit.opposite("down")
-      :up
-      iex> Data.Exit.opposite(:down)
-      :up
+      "up"
 
       iex> Data.Exit.opposite("in")
-      :out
-      iex> Data.Exit.opposite(:in)
-      :out
+      "out"
 
       iex> Data.Exit.opposite("out")
-      :in
-      iex> Data.Exit.opposite(:out)
-      :in
+      "in"
   """
   @spec opposite(String.t() | atom) :: atom
-  def opposite("north"), do: :south
-  def opposite("east"), do: :west
-  def opposite("south"), do: :north
-  def opposite("west"), do: :east
-  def opposite("up"), do: :down
-  def opposite("down"), do: :up
-  def opposite("in"), do: :out
-  def opposite("out"), do: :in
-  def opposite(:north), do: :south
-  def opposite(:east), do: :west
-  def opposite(:south), do: :north
-  def opposite(:west), do: :east
-  def opposite(:up), do: :down
-  def opposite(:down), do: :up
-  def opposite(:in), do: :out
-  def opposite(:out), do: :in
+  def opposite("north"), do: "south"
+  def opposite("east"), do: "west"
+  def opposite("south"), do: "north"
+  def opposite("west"), do: "east"
+  def opposite("up"), do: "down"
+  def opposite("down"), do: "up"
+  def opposite("in"), do: "out"
+  def opposite("out"), do: "in"
 
   @doc """
   Get an exit in a direction
   """
   @spec exit_to(Room.t(), String.t() | atom) :: Exit.t() | nil
   def exit_to(room, direction) do
-    Enum.find(room.exits, &(&1.direction == to_string(direction)))
+    Enum.find(room.exits, &(&1.direction == direction))
   end
 end

--- a/lib/data/exit.ex
+++ b/lib/data/exit.ex
@@ -8,7 +8,20 @@ defmodule Data.Exit do
   alias Data.Room
   alias Data.Zone
 
-  @directions ["north", "east", "south", "west", "up", "down", "in", "out"]
+  @directions [
+    "north",
+    "east",
+    "south",
+    "west",
+    "up",
+    "down",
+    "in",
+    "out",
+    "north west",
+    "north east",
+    "south west",
+    "south east"
+  ]
 
   schema "exits" do
     field(:direction, :string)
@@ -194,6 +207,18 @@ defmodule Data.Exit do
 
       iex> Data.Exit.opposite("out")
       "in"
+
+      iex> Data.Exit.opposite("north west")
+      "south east"
+
+      iex> Data.Exit.opposite("north east")
+      "south west"
+
+      iex> Data.Exit.opposite("south west")
+      "north east"
+
+      iex> Data.Exit.opposite("south east")
+      "north west"
   """
   @spec opposite(String.t() | atom) :: atom
   def opposite("north"), do: "south"
@@ -204,6 +229,10 @@ defmodule Data.Exit do
   def opposite("down"), do: "up"
   def opposite("in"), do: "out"
   def opposite("out"), do: "in"
+  def opposite("north west"), do: "south east"
+  def opposite("north east"), do: "south west"
+  def opposite("south west"), do: "north east"
+  def opposite("south east"), do: "north west"
 
   @doc """
   Get an exit in a direction

--- a/lib/game/command/listen.ex
+++ b/lib/game/command/listen.ex
@@ -37,7 +37,7 @@ defmodule Game.Command.Listen do
       {}
 
       iex> Game.Command.Listen.parse("listen north")
-      {:north}
+      {"north"}
 
       iex> Game.Command.Listen.parse("listen outside")
       {:error, :bad_parse, "listen outside"}
@@ -52,7 +52,7 @@ defmodule Game.Command.Listen do
   def parse("listen " <> direction) do
     case Exit.exit?(direction) do
       true ->
-        {String.to_atom(direction)}
+        {direction}
 
       false ->
         {:error, :bad_parse, "listen " <> direction}

--- a/lib/game/command/move.ex
+++ b/lib/game/command/move.ex
@@ -60,20 +60,20 @@ defmodule Game.Command.Move do
   @spec parse(command :: String.t()) :: {atom}
   def parse(commnd)
   def parse("move " <> direction), do: parse(direction)
-  def parse("north"), do: {:move, :north}
-  def parse("n"), do: {:move, :north}
-  def parse("east"), do: {:move, :east}
-  def parse("e"), do: {:move, :east}
-  def parse("south"), do: {:move, :south}
-  def parse("s"), do: {:move, :south}
-  def parse("west"), do: {:move, :west}
-  def parse("w"), do: {:move, :west}
-  def parse("up"), do: {:move, :up}
-  def parse("u"), do: {:move, :up}
-  def parse("down"), do: {:move, :down}
-  def parse("d"), do: {:move, :down}
-  def parse("in"), do: {:move, :in}
-  def parse("out"), do: {:move, :out}
+  def parse("north"), do: {:move, "north"}
+  def parse("n"), do: {:move, "north"}
+  def parse("east"), do: {:move, "east"}
+  def parse("e"), do: {:move, "east"}
+  def parse("south"), do: {:move, "south"}
+  def parse("s"), do: {:move, "south"}
+  def parse("west"), do: {:move, "west"}
+  def parse("w"), do: {:move, "west"}
+  def parse("up"), do: {:move, "up"}
+  def parse("u"), do: {:move, "up"}
+  def parse("down"), do: {:move, "down"}
+  def parse("d"), do: {:move, "down"}
+  def parse("in"), do: {:move, "in"}
+  def parse("out"), do: {:move, "out"}
 
   def parse("open " <> direction) do
     case parse(direction) do

--- a/lib/game/command/move.ex
+++ b/lib/game/command/move.ex
@@ -24,6 +24,10 @@ defmodule Game.Command.Move do
       {"west", ["w"]},
       {"up", ["u"]},
       {"down", ["d"]},
+      {"north west", ["nw"]},
+      {"north east", ["ne"]},
+      {"south west", ["sw"]},
+      {"south east", ["se"]},
       "in",
       "out",
       "open",
@@ -74,6 +78,14 @@ defmodule Game.Command.Move do
   def parse("d"), do: {:move, "down"}
   def parse("in"), do: {:move, "in"}
   def parse("out"), do: {:move, "out"}
+  def parse("north west"), do: {:move, "north west"}
+  def parse("nw"), do: {:move, "north west"}
+  def parse("north east"), do: {:move, "north east"}
+  def parse("ne"), do: {:move, "north east"}
+  def parse("south west"), do: {:move, "south west"}
+  def parse("sw"), do: {:move, "south west"}
+  def parse("south east"), do: {:move, "south east"}
+  def parse("se"), do: {:move, "south east"}
 
   def parse("open " <> direction) do
     case parse(direction) do

--- a/lib/game/command/run.ex
+++ b/lib/game/command/run.ex
@@ -9,7 +9,7 @@ defmodule Game.Command.Run do
   alias Game.Command.Move
   alias Game.Session.GMCP
 
-  @direction_regex ~r/(?<count>\d+)?(?<direction>[neswudio])/
+  @direction_regex ~r/(?<count>\d+)?(?<direction>[neswudio]{1,2})/
   @continue_wait Application.get_env(:ex_venture, :game)[:continue_wait]
 
   commands(["run"])
@@ -22,8 +22,23 @@ defmodule Game.Command.Run do
     """
     #{help(:short)}. You will stop running if an exit cannot be found.
 
+    You must provide a number before each direction. Possible directions are:
+
+    {white}n{/white}: north
+    {white}s{/white}: south
+    {white}e{/white}: east
+    {white}w{/white}: west
+    {white}i{/white}: in
+    {white}o{/white}: out
+    {white}u{/white}: up
+    {white}d{/white}: down
+    {white}nw{/white}: north west
+    {white}ne{/white}: north east
+    {white}sw{/white}: south west
+    {white}se{/white}: south east
+
     Example:
-    [ ] > {command}run 3en4s{/command}
+    [ ] > {command}run 3e1n4s{/command}
     """
   end
 
@@ -87,6 +102,7 @@ defmodule Game.Command.Run do
     |> String.split(@direction_regex, include_captures: true)
     |> Enum.reject(&(&1 == ""))
     |> Enum.flat_map(&expand_direction/1)
+    |> Enum.reject(&(&1 == :error))
   end
 
   @doc """
@@ -117,4 +133,9 @@ defmodule Game.Command.Run do
   def _direction("d"), do: "down"
   def _direction("i"), do: "in"
   def _direction("o"), do: "out"
+  def _direction("nw"), do: "north west"
+  def _direction("ne"), do: "north east"
+  def _direction("sw"), do: "south west"
+  def _direction("se"), do: "south east"
+  def _direction(_), do: :error
 end

--- a/lib/game/command/run.ex
+++ b/lib/game/command/run.ex
@@ -93,7 +93,7 @@ defmodule Game.Command.Run do
   Expand a single direction command into a list of directions
 
       iex> Game.Command.Run.expand_direction("3e")
-      [:east, :east, :east]
+      ["east", "east", "east"]
   """
   def expand_direction(direction) do
     case Regex.named_captures(@direction_regex, direction) do
@@ -109,12 +109,12 @@ defmodule Game.Command.Run do
     end
   end
 
-  def _direction("n"), do: :north
-  def _direction("e"), do: :east
-  def _direction("s"), do: :south
-  def _direction("w"), do: :west
-  def _direction("u"), do: :up
-  def _direction("d"), do: :down
-  def _direction("i"), do: :in
-  def _direction("o"), do: :out
+  def _direction("n"), do: "north"
+  def _direction("e"), do: "east"
+  def _direction("s"), do: "south"
+  def _direction("w"), do: "west"
+  def _direction("u"), do: "up"
+  def _direction("d"), do: "down"
+  def _direction("i"), do: "in"
+  def _direction("o"), do: "out"
 end

--- a/lib/game/map.ex
+++ b/lib/game/map.ex
@@ -122,9 +122,9 @@ defmodule Game.Map do
       |> color_room(room_color(room))
 
     [
-      exits(room, "north"),
+      "#{exits(room, "north west")}#{exits(room, "north")}#{exits(room, "north east")}",
       "#{exits(room, "west")}#{room_display}#{exits(room, "east")}",
-      exits(room, "south")
+      "#{exits(room, "south west")}#{exits(room, "south")}#{exits(room, "south east")}",
     ]
   end
 
@@ -137,10 +137,36 @@ defmodule Game.Map do
   defp exits(room, direction) when direction in ["north", "south"] do
     case Exit.exit_to(room, direction) do
       nil ->
-        "       "
+        "   "
 
       _ ->
-        "   |   "
+        " | "
+    end
+  end
+
+  defp exits(room, direction) when direction in ["north west", "south east"] do
+    case Exit.exit_to(room, direction) do
+      nil ->
+        "  "
+
+      %{direction: "north west"} ->
+        "\\ "
+
+      %{direction: "south east"} ->
+        " \\"
+    end
+  end
+
+  defp exits(room, direction) when direction in ["north east", "south west"] do
+    case Exit.exit_to(room, direction) do
+      nil ->
+        "  "
+
+      %{direction: "north east"} ->
+        " /"
+
+      %{direction: "south west"} ->
+        "/ "
     end
   end
 

--- a/lib/game/map.ex
+++ b/lib/game/map.ex
@@ -122,9 +122,9 @@ defmodule Game.Map do
       |> color_room(room_color(room))
 
     [
-      exits(room, :north),
-      "#{exits(room, :west)}#{room_display}#{exits(room, :east)}",
-      exits(room, :south)
+      exits(room, "north"),
+      "#{exits(room, "west")}#{room_display}#{exits(room, "east")}",
+      exits(room, "south")
     ]
   end
 
@@ -134,7 +134,7 @@ defmodule Game.Map do
   defp color_room(room_string, nil), do: room_string
   defp color_room(room_string, color), do: "{#{color}}#{room_string}{/#{color}}"
 
-  defp exits(room, direction) when direction in [:north, :south] do
+  defp exits(room, direction) when direction in ["north", "south"] do
     case Exit.exit_to(room, direction) do
       nil ->
         "       "
@@ -144,7 +144,7 @@ defmodule Game.Map do
     end
   end
 
-  defp exits(room, direction) when direction in [:east, :west] do
+  defp exits(room, direction) when direction in ["east", "west"] do
     case Exit.exit_to(room, direction) do
       nil ->
         "  "

--- a/lib/web/templates/admin/room/show.html.eex
+++ b/lib/web/templates/admin/room/show.html.eex
@@ -35,24 +35,10 @@
   </div>
 
   <div class="row">
-    <div class="col-md-4">
+    <div class="col-md-4 col-md-offset-4">
       <div class="box">
         <div class="box-body">
-          <%= render("_exit.html", conn: @conn, room: @room, direction: :up) %>
-        </div>
-      </div>
-    </div>
-    <div class="col-md-4">
-      <div class="box">
-        <div class="box-body">
-          <%= render("_exit.html", conn: @conn, room: @room, direction: :north) %>
-        </div>
-      </div>
-    </div>
-    <div class="col-md-4">
-      <div class="box">
-        <div class="box-body">
-          <%= render("_exit.html", conn: @conn, room: @room, direction: :out) %>
+          <%= render("_exit.html", conn: @conn, room: @room, direction: "north") %>
         </div>
       </div>
     </div>
@@ -61,37 +47,57 @@
     <div class="col-md-4">
       <div class="box">
         <div class="box-body">
-          <%= render("_exit.html", conn: @conn, room: @room, direction: :west) %>
+          <%= render("_exit.html", conn: @conn, room: @room, direction: "west") %>
         </div>
       </div>
     </div>
-    <div class="col-md-4">
+    <div class="col-md-4 col-md-offset-4">
       <div class="box">
         <div class="box-body">
-          <%= render("_exit.html", conn: @conn, room: @room, direction: :in) %>
-        </div>
-      </div>
-    </div>
-    <div class="col-md-4">
-      <div class="box">
-        <div class="box-body">
-          <%= render("_exit.html", conn: @conn, room: @room, direction: :east) %>
+          <%= render("_exit.html", conn: @conn, room: @room, direction: "east") %>
         </div>
       </div>
     </div>
   </div>
   <div class="row">
+    <div class="col-md-4 col-md-offset-4">
+      <div class="box">
+        <div class="box-body">
+          <%= render("_exit.html", conn: @conn, room: @room, direction: "south") %>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="row">
     <div class="col-md-4">
       <div class="box">
         <div class="box-body">
-          <%= render("_exit.html", conn: @conn, room: @room, direction: :down) %>
+          <%= render("_exit.html", conn: @conn, room: @room, direction: "up") %>
         </div>
       </div>
     </div>
     <div class="col-md-4">
       <div class="box">
         <div class="box-body">
-          <%= render("_exit.html", conn: @conn, room: @room, direction: :south) %>
+          <%= render("_exit.html", conn: @conn, room: @room, direction: "in") %>
+        </div>
+      </div>
+    </div>
+    <div class="col-md-4">
+      <div class="box">
+        <div class="box-body">
+          <%= render("_exit.html", conn: @conn, room: @room, direction: "out") %>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-md-4">
+      <div class="box">
+        <div class="box-body">
+          <%= render("_exit.html", conn: @conn, room: @room, direction: "down") %>
         </div>
       </div>
     </div>

--- a/lib/web/templates/admin/room/show.html.eex
+++ b/lib/web/templates/admin/room/show.html.eex
@@ -35,10 +35,24 @@
   </div>
 
   <div class="row">
-    <div class="col-md-4 col-md-offset-4">
+    <div class="col-md-4">
+      <div class="box">
+        <div class="box-body">
+          <%= render("_exit.html", conn: @conn, room: @room, direction: "north west") %>
+        </div>
+      </div>
+    </div>
+    <div class="col-md-4">
       <div class="box">
         <div class="box-body">
           <%= render("_exit.html", conn: @conn, room: @room, direction: "north") %>
+        </div>
+      </div>
+    </div>
+    <div class="col-md-4">
+      <div class="box">
+        <div class="box-body">
+          <%= render("_exit.html", conn: @conn, room: @room, direction: "north east") %>
         </div>
       </div>
     </div>
@@ -60,10 +74,24 @@
     </div>
   </div>
   <div class="row">
-    <div class="col-md-4 col-md-offset-4">
+    <div class="col-md-4">
+      <div class="box">
+        <div class="box-body">
+          <%= render("_exit.html", conn: @conn, room: @room, direction: "south west") %>
+        </div>
+      </div>
+    </div>
+    <div class="col-md-4">
       <div class="box">
         <div class="box-body">
           <%= render("_exit.html", conn: @conn, room: @room, direction: "south") %>
+        </div>
+      </div>
+    </div>
+    <div class="col-md-4">
+      <div class="box">
+        <div class="box-body">
+          <%= render("_exit.html", conn: @conn, room: @room, direction: "south east") %>
         </div>
       </div>
     </div>

--- a/test/data/exit_test.exs
+++ b/test/data/exit_test.exs
@@ -31,7 +31,7 @@ defmodule Data.ExitTest do
   test "find an exit" do
     room = %Room{id: 10, exits: [%{direction: "south", start_room_id: 10, finish_room_id: 11}]}
 
-    assert %{direction: "south"} = Exit.exit_to(room, :south)
+    assert %{direction: "south"} = Exit.exit_to(room, "south")
   end
 
   describe "validate start/finish fields" do

--- a/test/game/command/listen_test.exs
+++ b/test/game/command/listen_test.exs
@@ -79,14 +79,14 @@ defmodule Game.Command.ListenTest do
     end
 
     test "includes the room listen text", %{state: state} do
-      :ok = Listen.run({:north}, state)
+      :ok = Listen.run({"north"}, state)
 
       [{_socket, echo}] = @socket.get_echos()
       assert Regex.match?(~r/trickling/, echo)
     end
 
     test "nothing in specified direction", %{state: state} do
-      :ok = Listen.run({:south}, state)
+      :ok = Listen.run({"south"}, state)
 
       [{_socket, echo}] = @socket.get_echos()
       assert Regex.match?(~r/no exit/i, echo)

--- a/test/game/command/move_test.exs
+++ b/test/game/command/move_test.exs
@@ -43,14 +43,14 @@ defmodule Game.Command.MoveTest do
 
     test "north", %{state: state, room_exit: room_exit} do
       @room.set_room(%{@basic_room | exits: [room_exit]})
-      command = %Command{module: Command.Move, args: {:move, :north}}
+      command = %Command{module: Command.Move, args: {:move, "north"}}
       {:update, state} = Command.run(command, Map.merge(state, %{save: %{room_id: 1}}))
       assert state.save.room_id == 2
     end
 
     test "north - not found", %{state: state} do
       @room.set_room(%{@basic_room | exits: []})
-      command = %Command{module: Command.Move, args: {:move, :north}}
+      command = %Command{module: Command.Move, args: {:move, "north"}}
       {:error, :no_exit} = Command.run(command, Map.merge(state, %{save: %{room_id: 1}}))
     end
 
@@ -60,7 +60,7 @@ defmodule Game.Command.MoveTest do
       Door.load(room_exit)
       Door.set(room_exit, "closed")
 
-      command = %Command{module: Command.Move, args: {:move, :north}}
+      command = %Command{module: Command.Move, args: {:move, "north"}}
       {:update, state} = Command.run(command, Map.merge(state, %{save: %{room_id: 1}}))
 
       assert state.save.room_id == 2
@@ -75,7 +75,7 @@ defmodule Game.Command.MoveTest do
       Door.load(room_exit)
       Door.set(room_exit, "open")
 
-      command = %Command{module: Command.Move, args: {:move, :north}}
+      command = %Command{module: Command.Move, args: {:move, "north"}}
       {:update, state} = Command.run(command, Map.merge(state, %{save: %{room_id: 1}}))
 
       assert state.save.room_id == 2
@@ -87,7 +87,7 @@ defmodule Game.Command.MoveTest do
     Registry.register(user)
 
     state = Map.merge(state, %{user: user, save: %{room_id: 1}, target: {:user, 10}})
-    command = %Command{module: Command.Move, args: {:move, :north}}
+    command = %Command{module: Command.Move, args: {:move, "north"}}
     {:update, state} = Command.run(command, state)
 
     assert state.target == nil
@@ -106,7 +106,7 @@ defmodule Game.Command.MoveTest do
     end
 
     test "open the door", %{socket: socket, state: state} do
-      command = %Command{module: Command.Move, args: {:open, :north}}
+      command = %Command{module: Command.Move, args: {:open, "north"}}
       :ok = Command.run(command, Map.merge(state, %{save: %{room_id: 1}}))
 
       [{^socket, echo}] = @socket.get_echos()
@@ -119,7 +119,7 @@ defmodule Game.Command.MoveTest do
       room_exit = %{id: 10, direction: "north", start_id: 1, finish_id: 2, has_door: false}
       @room.set_room(%Game.Environment.State.Room{id: 1, name: "", description: "", exits: [room_exit], players: [], shops: []})
 
-      command = %Command{module: Command.Move, args: {:open, :north}}
+      command = %Command{module: Command.Move, args: {:open, "north"}}
       :ok = Command.run(command, Map.merge(state, %{save: %{room_id: 1}}))
 
       [{^socket, error}] = @socket.get_echos()
@@ -129,7 +129,7 @@ defmodule Game.Command.MoveTest do
     test "an exit does not exist in the direction", %{socket: socket, state: state} do
       @room.set_room(%Game.Environment.State.Room{id: 1, name: "", description: "", exits: [], players: [], shops: []})
 
-      command = %Command{module: Command.Move, args: {:open, :north}}
+      command = %Command{module: Command.Move, args: {:open, "north"}}
       :ok = Command.run(command, Map.merge(state, %{save: %{room_id: 1}}))
 
       [{^socket, error}] = @socket.get_echos()
@@ -139,7 +139,7 @@ defmodule Game.Command.MoveTest do
     test "door already open", %{socket: socket, state: state, room_exit: room_exit} do
       Door.set(room_exit, "open")
 
-      command = %Command{module: Command.Move, args: {:open, :north}}
+      command = %Command{module: Command.Move, args: {:open, "north"}}
       :ok = Command.run(command, Map.merge(state, %{save: %{room_id: 1}}))
 
       [{^socket, error}] = @socket.get_echos()
@@ -157,7 +157,7 @@ defmodule Game.Command.MoveTest do
     end
 
     test "close the door", %{socket: socket, state: state} do
-      command = %Command{module: Command.Move, args: {:close, :north}}
+      command = %Command{module: Command.Move, args: {:close, "north"}}
       :ok = Command.run(command, Map.merge(state, %{save: %{room_id: 1}}))
 
       [{^socket, echo}] = @socket.get_echos()
@@ -170,7 +170,7 @@ defmodule Game.Command.MoveTest do
       room_exit = %{id: 10, direction: "north", start_id: 1, finish_id: 2, has_door: false}
       @room.set_room(%Game.Environment.State.Room{id: 1, name: "", description: "", exits: [room_exit], players: [], shops: []})
 
-      command = %Command{module: Command.Move, args: {:close, :north}}
+      command = %Command{module: Command.Move, args: {:close, "north"}}
       :ok = Command.run(command, Map.merge(state, %{save: %{room_id: 1}}))
 
       [{^socket, error}] = @socket.get_echos()
@@ -180,7 +180,7 @@ defmodule Game.Command.MoveTest do
     test "an exit does not exist in the direction", %{socket: socket, state: state} do
       @room.set_room(%Game.Environment.State.Room{id: 1, name: "", description: "", exits: [], players: [], shops: []})
 
-      command = %Command{module: Command.Move, args: {:close, :north}}
+      command = %Command{module: Command.Move, args: {:close, "north"}}
       :ok = Command.run(command, Map.merge(state, %{save: %{room_id: 1}}))
 
       [{^socket, error}] = @socket.get_echos()
@@ -190,7 +190,7 @@ defmodule Game.Command.MoveTest do
     test "door already closed", %{socket: socket, state: state, room_exit: room_exit} do
       Door.set(room_exit, "closed")
 
-      command = %Command{module: Command.Move, args: {:close, :north}}
+      command = %Command{module: Command.Move, args: {:close, "north"}}
       :ok = Command.run(command, Map.merge(state, %{save: %{room_id: 1}}))
 
       [{^socket, error}] = @socket.get_echos()
@@ -208,7 +208,7 @@ defmodule Game.Command.MoveTest do
         save: %{room_id: 1}
       })
 
-      :ok = Move.run({:move, :north}, state)
+      :ok = Move.run({:move, "north"}, state)
 
       [{_socket, echo}] = @socket.get_echos()
       assert Regex.match?(~r(cannot move)i, echo)

--- a/test/game/command/run_test.exs
+++ b/test/game/command/run_test.exs
@@ -38,35 +38,35 @@ defmodule Game.Command.RunTest do
     {:update, state, continue_command} = Command.Run.run({"nen"}, state)
 
     assert state.save.room_id == 2
-    assert continue_command == {%Command{module: Command.Run, args: {[:east, :north]}, continue: true}, 10}
+    assert continue_command == {%Command{module: Command.Run, args: {["east", "north"]}, continue: true}, 10}
   end
 
   test "continue running in the processed set of directions", %{state: state} do
-    {:update, state, continue_command} = Command.Run.run({[:north, :east]}, state)
+    {:update, state, continue_command} = Command.Run.run({["north", "east"]}, state)
 
     assert state.save.room_id == 2
-    assert continue_command == {%Command{module: Command.Run, args: {[:east]}, continue: true}, 10}
+    assert continue_command == {%Command{module: Command.Run, args: {["east"]}, continue: true}, 10}
   end
 
   test "end of the run", %{state: state} do
-    {:update, state} = Command.Run.run({[:north]}, state)
+    {:update, state} = Command.Run.run({["north"]}, state)
 
     assert state.save.room_id == 2
   end
 
   test "failure to move in a direction stops the run", %{state: state} do
-    :ok = Command.Run.run({[:east, :north]}, state)
+    :ok = Command.Run.run({["east", "north"]}, state)
 
     assert @socket.get_echos() == [{:socket, "Could not move east, no exit found."}]
   end
 
   describe "parsing run directions" do
     test "expand directions" do
-      assert Command.Run.parse_run("2en3s1u2d") == [:east, :east, :north, :south, :south, :south, :up, :down, :down]
+      assert Command.Run.parse_run("2en3s1u2d") == ["east", "east", "north", "south", "south", "south", "up", "down", "down"]
     end
 
     test "handles bad input" do
-      assert Command.Run.parse_run("2ef3s") == [:east, :east, :south, :south, :south]
+      assert Command.Run.parse_run("2ef3s") == ["east", "east", "south", "south", "south"]
     end
 
     test "handles no directions" do

--- a/test/game/command/run_test.exs
+++ b/test/game/command/run_test.exs
@@ -35,7 +35,7 @@ defmodule Game.Command.RunTest do
   end
 
   test "run in a set of directions", %{state: state} do
-    {:update, state, continue_command} = Command.Run.run({"nen"}, state)
+    {:update, state, continue_command} = Command.Run.run({"1n1e1n"}, state)
 
     assert state.save.room_id == 2
     assert continue_command == {%Command{module: Command.Run, args: {["east", "north"]}, continue: true}, 10}
@@ -62,11 +62,12 @@ defmodule Game.Command.RunTest do
 
   describe "parsing run directions" do
     test "expand directions" do
-      assert Command.Run.parse_run("2en3s1u2d") == ["east", "east", "north", "south", "south", "south", "up", "down", "down"]
+      assert Command.Run.parse_run("2e1n3s1u2d") == ["east", "east", "north", "south", "south", "south", "up", "down", "down"]
     end
 
     test "handles bad input" do
       assert Command.Run.parse_run("2ef3s") == ["east", "east", "south", "south", "south"]
+      assert Command.Run.parse_run("2en3s") == ["south", "south", "south"]
     end
 
     test "handles no directions" do

--- a/test/game/command_test.exs
+++ b/test/game/command_test.exs
@@ -66,51 +66,51 @@ defmodule Game.CommandTest do
     end
 
     test "open", %{user: user} do
-      assert %Command{module: Command.Move, args: {:open, :north}} = Command.parse("open north", user)
-      assert %Command{module: Command.Move, args: {:open, :north}} = Command.parse("open n", user)
+      assert %Command{module: Command.Move, args: {:open, "north"}} = Command.parse("open north", user)
+      assert %Command{module: Command.Move, args: {:open, "north"}} = Command.parse("open n", user)
       assert {:error, :bad_parse, "open unknown"} = Command.parse("open unknown", user)
     end
 
     test "close", %{user: user} do
-      assert %Command{module: Command.Move, args: {:close, :north}} = Command.parse("close north", user)
-      assert %Command{module: Command.Move, args: {:close, :north}} = Command.parse("close n", user)
+      assert %Command{module: Command.Move, args: {:close, "north"}} = Command.parse("close north", user)
+      assert %Command{module: Command.Move, args: {:close, "north"}} = Command.parse("close n", user)
       assert {:error, :bad_parse, "close unknown"} = Command.parse("close unknown", user)
     end
 
     test "north", %{user: user} do
-      assert %Command{module: Command.Move, args: {:move, :north}} = Command.parse("move north", user)
-      assert %Command{module: Command.Move, args: {:move, :north}} = Command.parse("north", user)
-      assert %Command{module: Command.Move, args: {:move, :north}} = Command.parse("n", user)
+      assert %Command{module: Command.Move, args: {:move, "north"}} = Command.parse("move north", user)
+      assert %Command{module: Command.Move, args: {:move, "north"}} = Command.parse("north", user)
+      assert %Command{module: Command.Move, args: {:move, "north"}} = Command.parse("n", user)
     end
 
     test "east", %{user: user} do
-      assert %Command{module: Command.Move, args: {:move, :east}} = Command.parse("move east", user)
-      assert %Command{module: Command.Move, args: {:move, :east}} = Command.parse("east", user)
-      assert %Command{module: Command.Move, args: {:move, :east}} = Command.parse("e", user)
+      assert %Command{module: Command.Move, args: {:move, "east"}} = Command.parse("move east", user)
+      assert %Command{module: Command.Move, args: {:move, "east"}} = Command.parse("east", user)
+      assert %Command{module: Command.Move, args: {:move, "east"}} = Command.parse("e", user)
     end
 
     test "south", %{user: user} do
-      assert %Command{module: Command.Move, args: {:move, :south}} = Command.parse("move south", user)
-      assert %Command{module: Command.Move, args: {:move, :south}} = Command.parse("south", user)
-      assert %Command{module: Command.Move, args: {:move, :south}} = Command.parse("s", user)
+      assert %Command{module: Command.Move, args: {:move, "south"}} = Command.parse("move south", user)
+      assert %Command{module: Command.Move, args: {:move, "south"}} = Command.parse("south", user)
+      assert %Command{module: Command.Move, args: {:move, "south"}} = Command.parse("s", user)
     end
 
     test "west", %{user: user} do
-      assert %Command{module: Command.Move, args: {:move, :west}} = Command.parse("move west", user)
-      assert %Command{module: Command.Move, args: {:move, :west}} = Command.parse("west", user)
-      assert %Command{module: Command.Move, args: {:move, :west}} = Command.parse("w", user)
+      assert %Command{module: Command.Move, args: {:move, "west"}} = Command.parse("move west", user)
+      assert %Command{module: Command.Move, args: {:move, "west"}} = Command.parse("west", user)
+      assert %Command{module: Command.Move, args: {:move, "west"}} = Command.parse("w", user)
     end
 
     test "up", %{user: user} do
-      assert %Command{module: Command.Move, args: {:move, :up}} = Command.parse("move up", user)
-      assert %Command{module: Command.Move, args: {:move, :up}} = Command.parse("up", user)
-      assert %Command{module: Command.Move, args: {:move, :up}} = Command.parse("u", user)
+      assert %Command{module: Command.Move, args: {:move, "up"}} = Command.parse("move up", user)
+      assert %Command{module: Command.Move, args: {:move, "up"}} = Command.parse("up", user)
+      assert %Command{module: Command.Move, args: {:move, "up"}} = Command.parse("u", user)
     end
 
     test "down", %{user: user} do
-      assert %Command{module: Command.Move, args: {:move, :down}} = Command.parse("move down", user)
-      assert %Command{module: Command.Move, args: {:move, :down}} = Command.parse("down", user)
-      assert %Command{module: Command.Move, args: {:move, :down}} = Command.parse("d", user)
+      assert %Command{module: Command.Move, args: {:move, "down"}} = Command.parse("move down", user)
+      assert %Command{module: Command.Move, args: {:move, "down"}} = Command.parse("down", user)
+      assert %Command{module: Command.Move, args: {:move, "down"}} = Command.parse("d", user)
     end
 
     test "inventory", %{user: user} do
@@ -279,7 +279,7 @@ defmodule Game.CommandTest do
 
   test "limit commands to be above 0 hp to perform", %{socket: socket} do
     save = %{stats: %{health_points: 0}}
-    command = %Command{module: Command.Move, args: {:north}}
+    command = %Command{module: Command.Move, args: {"north"}}
     :ok = Command.run(command, %{socket: socket, save: save})
     assert @socket.get_echos() == [{socket, "You are passed out and cannot perform this action."}]
   end

--- a/test/game/session_test.exs
+++ b/test/game/session_test.exs
@@ -162,7 +162,7 @@ defmodule Game.SessionTest do
     {:noreply, state} = Process.handle_cast({:recv, "run 2n"}, state)
 
     assert state.mode == "continuing"
-    assert_receive {:continue, %Command{module: Command.Run, args: {[:north]}}}
+    assert_receive {:continue, %Command{module: Command.Run, args: {["north"]}}}
   after
     Session.Registry.unregister()
   end
@@ -173,10 +173,10 @@ defmodule Game.SessionTest do
 
     @room.set_room(%{@basic_room | exits: [%{direction: "north", start_id: 1, finish_id: 2}]})
     state = %{state | user: user, save: %{room_id: 1, experience_points: 10, stats: %{base_stats() | endurance_points: 10}}, regen: %{is_regenerating: false}}
-    command = %Command{module: Command.Run, args: {[:north, :north]}}
+    command = %Command{module: Command.Run, args: {["north", "north"]}}
     {:noreply, _state} = Process.handle_info({:continue, command}, state)
 
-    assert_receive {:continue, %Command{module: Command.Run, args: {[:north]}}}
+    assert_receive {:continue, %Command{module: Command.Run, args: {["north"]}}}
   after
     Session.Registry.unregister()
   end
@@ -460,34 +460,34 @@ defmodule Game.SessionTest do
 
   describe "event notification" do
     test "player enters the room", %{state: state} do
-      {:noreply, ^state} = Process.handle_cast({:notify, {"room/entered", {{:user, %{id: 1, name: "Player"}}, {:enter, :south}}}}, state)
+      {:noreply, ^state} = Process.handle_cast({:notify, {"room/entered", {{:user, %{id: 1, name: "Player"}}, {:enter, "south"}}}}, state)
       [{_, "{player}Player{/player} enters from the {command}south{/command}."}] = @socket.get_echos()
     end
 
     test "npc enters the room", %{state: state} do
-      {:noreply, ^state} = Process.handle_cast({:notify, {"room/entered", {{:npc, %{id: 1, name: "Bandit"}}, {:enter, :south}}}}, state)
+      {:noreply, ^state} = Process.handle_cast({:notify, {"room/entered", {{:npc, %{id: 1, name: "Bandit"}}, {:enter, "south"}}}}, state)
       [{_, "{npc}Bandit{/npc} enters from the {command}south{/command}."}] = @socket.get_echos()
     end
 
     test "player leaves the room", %{state: state} do
-      {:noreply, ^state} = Process.handle_cast({:notify, {"room/leave", {{:user, %{id: 1, name: "Player"}}, {:leave, :north}}}}, state)
+      {:noreply, ^state} = Process.handle_cast({:notify, {"room/leave", {{:user, %{id: 1, name: "Player"}}, {:leave, "north"}}}}, state)
       [{_, "{player}Player{/player} leaves heading {command}north{/command}."}] = @socket.get_echos()
     end
 
     test "npc leaves the room", %{state: state} do
-      {:noreply, ^state} = Process.handle_cast({:notify, {"room/leave", {{:npc, %{id: 1, name: "Bandit"}}, {:leave, :north}}}}, state)
+      {:noreply, ^state} = Process.handle_cast({:notify, {"room/leave", {{:npc, %{id: 1, name: "Bandit"}}, {:leave, "north"}}}}, state)
       [{_, "{npc}Bandit{/npc} leaves heading {command}north{/command}."}] = @socket.get_echos()
     end
 
     test "player leaves the room and they were the target", %{state: state} do
       state = %{state | target: {:user, 1}}
-      {:noreply, state} = Process.handle_cast({:notify, {"room/leave", {{:user, %{id: 1, name: "Player"}}, {:leave, :north}}}}, state)
+      {:noreply, state} = Process.handle_cast({:notify, {"room/leave", {{:user, %{id: 1, name: "Player"}}, {:leave, "north"}}}}, state)
       assert is_nil(state.target)
     end
 
     test "npc leaves the room and they were the target", %{state: state} do
       state = %{state | target: {:npc, 1}}
-      {:noreply, state} = Process.handle_cast({:notify, {"room/leave", {{:npc, %{id: 1, name: "Bandit"}}, {:leave, :north}}}}, state)
+      {:noreply, state} = Process.handle_cast({:notify, {"room/leave", {{:npc, %{id: 1, name: "Bandit"}}, {:leave, "north"}}}}, state)
       assert is_nil(state.target)
     end
 


### PR DESCRIPTION
Movement in `north west`, `north east`, `south west`, and `south east` directions.

This also moves all exits to strings, which might help for custom exits later on.