### PR TITLE
Template context

### DIFF
--- a/lib/game/format.ex
+++ b/lib/game/format.ex
@@ -244,6 +244,7 @@ defmodule Game.Format do
 
   defp room_description(room) do
     context()
+    |> assign(:room, room.name)
     |> assign(:zone, room.zone.name)
     |> template(room.description)
   end

--- a/lib/game/format.ex
+++ b/lib/game/format.ex
@@ -227,7 +227,7 @@ defmodule Game.Format do
   """
   @spec room(Room.t(), [Item.t()], Map.t()) :: String.t()
   def room(room, items, map) do
-    description = "#{room.description} #{room.features |> features() |> Enum.join(" ")}"
+    description = "#{room_description(room)} #{room.features |> features() |> Enum.join(" ")}"
 
     """
     #{room_name(room)}
@@ -240,6 +240,12 @@ defmodule Game.Format do
     #{maybe_exits(room)}#{maybe_items(room, items)}#{shops(room)}
     """
     |> String.trim()
+  end
+
+  defp room_description(room) do
+    context()
+    |> assign(:zone, room.zone.name)
+    |> template(room.description)
   end
 
   def room_name(room) do

--- a/lib/game/format/context.ex
+++ b/lib/game/format/context.ex
@@ -1,0 +1,43 @@
+defmodule Game.Format.Context do
+  @moduledoc """
+  Context token struct for formatting and templating.
+
+  Similar to a Phoenix connection struct
+  """
+
+  @doc """
+  Context struct for formatting strings
+
+  - `assigns`: map of key/values to template
+  """
+  defstruct [assigns: %{}]
+
+  @doc """
+  Start with a base conntext
+  """
+  def context() do
+    %__MODULE__{}
+  end
+
+  @doc """
+  Assign a new template variable
+  """
+  def assign(context, key, value) do
+    assigns =
+      context
+      |> Map.get(:assigns, %{})
+      |> Map.put(key, value)
+
+    %{context | assigns: assigns}
+  end
+
+  def assign(context, map) do
+    assigns =
+      context
+      |> Map.get(:assigns, %{})
+
+    assigns = Enum.into(map, assigns)
+
+    %{context | assigns: assigns}
+  end
+end

--- a/lib/game/format/listen.ex
+++ b/lib/game/format/listen.ex
@@ -5,6 +5,8 @@ defmodule Game.Format.Listen do
 
   alias Game.Format
 
+  import Game.Format.Context
+
   def to_room(room) do
     features =
       room.features
@@ -18,11 +20,16 @@ defmodule Game.Format.Listen do
       room.npcs
       |> Enum.reject(&(is_nil(&1.status_listen) || &1.status_listen == ""))
       |> Enum.map(fn npc ->
-        npc.status_listen |> Format.template(%{name: Format.npc_name(npc)})
+        context()
+        |> assign(:name, Format.npc_name(npc))
+        |> Format.template(npc.status_listen)
       end)
 
-    "{white}You can hear:{/white}[\nroom][\nfeatures][\nnpcs]"
-    |> Format.template(%{room: room.listen, features: features, npcs: npcs})
+    context()
+    |> assign(:room, room.listen)
+    |> assign(:features, features)
+    |> assign(:npcs, npcs)
+    |> Format.template("{white}You can hear:{/white}[\nroom][\nfeatures][\nnpcs]")
     |> Format.wrap()
   end
 end

--- a/lib/game/format/template.ex
+++ b/lib/game/format/template.ex
@@ -21,9 +21,10 @@ defmodule Game.Format.Template do
       You say, {say}"Hello"{/say}
   """
   @spec render(String.t(), map()) :: String.t()
-  def render(string, context) do
+  def render(context, string) do
     context =
       context
+      |> Map.get(:assigns, %{})
       |> Enum.map(fn {key, val} -> {to_string(key), val} end)
       |> Enum.into(%{})
 

--- a/lib/game/hint.ex
+++ b/lib/game/hint.ex
@@ -6,14 +6,16 @@ defmodule Game.Hint do
   use ExVenture.TextCompiler, "help/hint.help"
   use Networking.Socket
 
+  import Game.Format.Context, only: [context: 0, assign: 2]
+
   alias Game.Format
 
   def hint(key, context) do
-    context = Enum.into(context, %{})
+    assigns = Enum.into(context, %{})
 
-    key
-    |> get()
-    |> Format.template(context)
+    context()
+    |> assign(assigns)
+    |> Format.template(get(key))
   end
 
   def gate(state, key, context \\ %{}) do

--- a/lib/web/templates/admin/room/_form.html.eex
+++ b/lib/web/templates/admin/room/_form.html.eex
@@ -6,7 +6,9 @@
 
       <%= FormView.text_field(f, :name) %>
 
-      <%= FormView.textarea_field(f, :description, rows: 5) %>
+      <%= FormView.textarea_field(f, :description, rows: 5) do %>
+        <span class="help-block">Available template replacements: <code>zone</code></span>
+      <% end %>
 
       <%= FormView.textarea_field(f, :listen, rows: 5) %>
 

--- a/lib/web/templates/admin/room/_form.html.eex
+++ b/lib/web/templates/admin/room/_form.html.eex
@@ -7,7 +7,7 @@
       <%= FormView.text_field(f, :name) %>
 
       <%= FormView.textarea_field(f, :description, rows: 5) do %>
-        <span class="help-block">Available template replacements: <code>zone</code></span>
+        <span class="help-block">Available template replacements: <code>room</code>, <code>zone</code></span>
       <% end %>
 
       <%= FormView.textarea_field(f, :listen, rows: 5) %>

--- a/test/game/format/context_test.exs
+++ b/test/game/format/context_test.exs
@@ -1,0 +1,30 @@
+defmodule Game.Format.ContextTest do
+  use ExUnit.Case
+
+  alias Game.Format.Context
+
+  describe "assigning variables" do
+    setup do
+      %{context: %Context{}}
+    end
+
+    test "assign a new variable", %{context: context} do
+      context = Context.assign(context, :variable, :value)
+
+      assert context.assigns.variable == :value
+    end
+
+    test "replace a variable", %{context: context} do
+      context = Context.assign(context, :variable, :value)
+      context = Context.assign(context, :variable, :new_value)
+
+      assert context.assigns.variable == :new_value
+    end
+
+    test "mass assign variables", %{context: context} do
+      context = Context.assign(context, %{variable: :value})
+
+      assert context.assigns.variable == :value
+    end
+  end
+end

--- a/test/game/format/template_test.exs
+++ b/test/game/format/template_test.exs
@@ -2,41 +2,55 @@ defmodule Game.Format.TemplateTest do
   use ExUnit.Case
   doctest Game.Format.Template
 
+  import Game.Format.Context, only: [context: 0]
+
+  alias Game.Format.Context
   alias Game.Format.Template
 
   test "simple template" do
-    assert Template.render("[name]", %{name: "Player"}) == "Player"
+    context = Context.assign(context(), :name, "Player")
+
+    assert Template.render(context, "[name]") == "Player"
   end
 
   describe "variable can include spaces" do
-    test "includes the space" do
-      assert Template.render("[ name]", %{name: "Player"}) == " Player"
+    setup do
+      %{context: %Context{assigns: %{}}}
     end
 
-    test "includes newlines" do
-      assert Template.render("[\nname]", %{name: "Player"}) == "\nPlayer"
+    test "includes the space", %{context: context} do
+      context = Context.assign(context, :name, "Player")
+
+      assert Template.render(context, "[ name]") == " Player"
     end
 
-    test "if key not found skips the space" do
-      assert Template.render("[ name]", %{}) == ""
+    test "includes newlines", %{context: context} do
+      context = Context.assign(context, :name, "Player")
+
+      assert Template.render(context, "[\nname]") == "\nPlayer"
     end
 
-    test "if key not found skips newlines" do
-      assert Template.render("[\nname]", %{}) == ""
+    test "if key not found skips the space", %{context: context} do
+      assert Template.render(context, "[ name]") == ""
     end
 
-    test "empty strings are considered 'nil'" do
-      assert Template.render("[\nname]", %{name: ""}) == ""
+    test "if key not found skips newlines", %{context: context} do
+      assert Template.render(context, "[\nname]") == ""
+    end
+
+    test "empty strings are considered 'nil'", %{context: context} do
+      context = Context.assign(context, :name, "")
+
+      assert Template.render(context, "[\nname]") == ""
     end
   end
 
   test "nil variables are treated as empty" do
     string =
-      ~s(You say[ adverb_phrase], {say}"[message]"{/say})
-      |> Template.render(%{
-        message: "Hello",
-        adverb_phrase: nil,
-      })
+      context()
+      |> Context.assign(:message, "Hello")
+      |> Context.assign(:adverb_phrase, nil)
+      |> Template.render(~s(You say[ adverb_phrase], {say}"[message]"{/say}))
 
     assert string == "You say, {say}\"Hello\"{/say}"
   end

--- a/test/game/format_test.exs
+++ b/test/game/format_test.exs
@@ -72,6 +72,7 @@ defmodule Game.FormatTest do
       room = %{
         id: 1,
         name: "Hallway",
+        zone: %{name: "Cave"},
         description: "A hallway",
         currency: 100,
         players: [%{name: "Player"}],


### PR DESCRIPTION
Reverse the template functions, take a context token first. Formalizes
the context struct more to look more like a phoenix connection struct.

Template the room name and zone name in the room description.