### PR TITLE
Enable babel webpack treeshaking interop & update npm scripts

### DIFF
--- a/assets/.babelrc
+++ b/assets/.babelrc
@@ -1,6 +1,11 @@
 {
     "presets": [
-        "@babel/preset-env",
+        [
+            "@babel/preset-env",
+            {
+                "modules": false
+            }
+        ],
         "@babel/preset-react"
     ]
 }

--- a/assets/package.json
+++ b/assets/package.json
@@ -2,8 +2,8 @@
   "repository": {},
   "license": "MIT",
   "scripts": {
-    "deploy": "brunch build --production",
-    "watch": "brunch watch --stdin"
+    "deploy": "webpack --mode production",
+    "watch": "webpack --mode development --watch"
   },
   "dependencies": {
     "admin-lte": "^2.4.8",


### PR DESCRIPTION
Disabled babel transpiling modules to commonJS in @babel/preset-env so webpack can do the transpiling in order to allow for treeshaking.  Per webpack documentation, CommonJS is not treeshakable. https://webpack.js.org/guides/tree-shaking/

Also updating the `build` and `watch` npm script to use webpack instead of brunch.  These can be referenced to update the release.sh script to create a production build.
