### PR TITLE
Enable Greedy matching for command parsing

### DIFF
--- a/assets/play/js/color.js
+++ b/assets/play/js/color.js
@@ -52,7 +52,7 @@ function formatColor(payload) {
   string = string.replace(/{link click=false}/g, defaultColor('link', 'white'));
 
   string = string.replace(
-    /{command( send='(.*)')?}/g,
+    /{command( send=['"](.*?)['"])?}/g,
     (_match, _fullSend, command) => {
       let color = defaultColorCSS('command', 'white');
       if (payload.delink == undefined || payload.delink == false) {

--- a/assets/play_react/js/utils/color.js
+++ b/assets/play_react/js/utils/color.js
@@ -55,7 +55,7 @@ function formatColor(payload) {
   string = string.replace(/{link click=false}/g, defaultColor('link', 'white'));
 
   string = string.replace(
-    /{command( send=['"](.*)['"])?}/g,
+    /{command( send=['"](.*?)['"])?}/g,
     (_match, _fullSend, command) => {
       command = stripColor(command);
       let color = defaultColorCSS('command', 'white');


### PR DESCRIPTION
- Enable greedy matching for command parsing in Colorjs for both current and react client.
- Allow both single and double quotes for command parsing of 'send' attribute in colorjs.