### PR TITLE
Refactor room tests

### DIFF
--- a/test/game/command/afk_test.exs
+++ b/test/game/command/afk_test.exs
@@ -1,5 +1,5 @@
 defmodule Game.Command.AFKTest do
-  use ExVenture.CommandCase, async: true
+  use ExVenture.CommandCase
 
   alias Game.Command.AFK
 

--- a/test/game/command/afk_test.exs
+++ b/test/game/command/afk_test.exs
@@ -1,8 +1,9 @@
 defmodule Game.Command.AFKTest do
-  use Data.ModelCase
-  doctest Game.Command.AFK
+  use ExVenture.CommandCase, async: true
 
   alias Game.Command.AFK
+
+  doctest AFK
 
   describe "go afk" do
     setup do

--- a/test/game/command/crash_test.exs
+++ b/test/game/command/crash_test.exs
@@ -5,11 +5,7 @@ defmodule Game.Command.CrashTest do
 
   doctest Crash
 
-  @room Test.Game.Room
-
   setup do
-    @room.clear_crashes()
-
     user = create_user(%{name: "user", password: "password", flags: ["admin"]})
     %{state: %{socket: :socket, user: user, save: %{room_id: 10}}}
   end
@@ -18,10 +14,7 @@ defmodule Game.Command.CrashTest do
     test "sends a signal to crash the room you are in", %{state: state} do
       :ok = Crash.run({:room}, state)
 
-      assert_receive {:echo, _, message}
-      assert Regex.match?(~r(crash)i, message)
-
-      assert [10] == @room.get_crashes()
+      assert_socket_echo "crash"
     end
 
     test "you must be an admin", %{state: state} do
@@ -29,10 +22,7 @@ defmodule Game.Command.CrashTest do
 
       :ok = Crash.run({:room}, state)
 
-      assert_receive {:echo, _, message}
-      assert Regex.match?(~r(must be an admin)i, message)
-
-      assert [] == @room.get_crashes()
+      assert_socket_echo "must be an admin"
     end
   end
 end

--- a/test/game/command/drop_test.exs
+++ b/test/game/command/drop_test.exs
@@ -1,8 +1,6 @@
 defmodule Game.Command.DropTest do
   use ExVenture.CommandCase
 
-  @room Test.Game.Room
-
   alias Game.Command.Drop
 
   setup do
@@ -16,8 +14,6 @@ defmodule Game.Command.DropTest do
   end
 
   test "drop an item in a room", %{state: state} do
-    @room.clear_drops()
-
     state = %{state | save: %{state.save | room_id: 1, items: [item_instance(1)]}}
 
     {:update, state} = Drop.run({"sword"}, state)
@@ -25,27 +21,22 @@ defmodule Game.Command.DropTest do
     assert state.save.items |> length == 0
 
     assert_socket_echo "you dropped"
-
-    assert [{1, {:player, _}, %{id: 1}}] = @room.get_drops()
+    assert_drop {_, {:player, _}, %{id: 1}}
   end
 
   test "drop currency in a room", %{state: state} do
-    @room.clear_drop_currencies()
-
     state = %{state | save: %{state.save | room_id: 1, currency: 101}}
     {:update, state} = Drop.run({"100 gold"}, state)
 
     assert state.save.currency == 1
 
     assert_socket_echo "you dropped"
-
-    assert [{1, {:player, _}, 100}] = @room.get_drop_currencies()
+    assert_drop {_, {:player, _}, {:currency, 100}}
   end
 
   test "drop currency in a room - not enough to do so", %{state: state} do
-    @room.clear_drop_currencies()
-
     state = %{state | save: %{state.save | room_id: 1, currency: 101}}
+
     :ok = Drop.run({"110 gold"}, state)
 
     assert_socket_echo "you do not have enough"

--- a/test/game/command/emote_test.exs
+++ b/test/game/command/emote_test.exs
@@ -2,21 +2,16 @@ defmodule Game.Command.EmoteTest do
   use ExVenture.CommandCase
 
   alias Game.Command.Emote
-  alias Game.Message
 
   doctest Emote
 
-  @room Test.Game.Room
-
   setup do
-    @room.clear_emotes()
-
     %{state: session_state(%{user: base_user()})}
   end
 
   test "send an emote to the room", %{state: state} do
     :ok = Emote.run({"does something"}, state)
 
-    assert @room.get_emotes() == [{1, Message.emote(state.character, "does something")}]
+    assert_emote "does something"
   end
 end

--- a/test/game/command/give_test.exs
+++ b/test/game/command/give_test.exs
@@ -5,8 +5,6 @@ defmodule Game.Command.GiveTest do
 
   doctest Give
 
-  @room Test.Game.Room
-
   setup do
     user = create_user(%{name: "user", password: "password"})
     character = create_character(user)
@@ -15,12 +13,10 @@ defmodule Game.Command.GiveTest do
 
   describe "giving items away" do
     setup %{state: state} do
-      room = Map.merge(@room._room(), %{
+      start_room(%{
         npcs: [npc_attributes(%{id: 1, name: "Guard"})],
         players: [user_attributes(%{id: 1, name: "Player"})],
       })
-
-      @room.set_room(room)
 
       start_and_clear_items()
       insert_item(%{id: 1, name: "potion", keywords: []})

--- a/test/game/command/greet_test.exs
+++ b/test/game/command/greet_test.exs
@@ -5,7 +5,6 @@ defmodule Game.Command.GreetTest do
 
   doctest Greet
 
-  @room Test.Game.Room
   @npc Test.Game.NPC
 
   setup do
@@ -17,7 +16,7 @@ defmodule Game.Command.GreetTest do
       npcs: [npc_attributes(%{id: 1, name: "Guard"})],
       players: [user_attributes(%{id: 1, name: "Player"})],
     }
-    @room.set_room(Map.merge(@room._room(), room))
+    start_room(room)
 
     save = %{character.save | room_id: room.id}
     %{state: session_state(%{user: user, character: character, save: save})}

--- a/test/game/command/listen_test.exs
+++ b/test/game/command/listen_test.exs
@@ -5,8 +5,6 @@ defmodule Game.Command.ListenTest do
 
   doctest Listen
 
-  @room Test.Game.Room
-
   setup do
     save = base_save()
     %{state: %{socket: :socket, user: %{save: save}, save: save}}
@@ -23,13 +21,13 @@ defmodule Game.Command.ListenTest do
           %{name: "Guard", extra: %{status_listen: "[name] is yelling."}},
         ],
       }
-      @room.set_room(Map.merge(@room._room(), room))
+      start_room(room)
 
       :ok
     end
 
     test "room contains no listening text", %{state: state} do
-      @room.set_room(@room._room())
+      start_room(%{})
 
       :ok = Listen.run({}, state)
 
@@ -58,7 +56,7 @@ defmodule Game.Command.ListenTest do
   describe "listening in a direction" do
     setup do
       room = %{id: 1, exits: [%{direction: "north", start_id: 1, finish_id: 2}]}
-      @room.set_room(Map.merge(@room._room(), room), multiple: true)
+      start_room(room)
 
       room = %{
         id: 2,
@@ -67,7 +65,7 @@ defmodule Game.Command.ListenTest do
           %{key: "flag", listen: "A flag is flapping in the breeze"},
         ],
       }
-      @room.set_room(Map.merge(@room._room(), room), multiple: true)
+      start_room(room)
 
       :ok
     end

--- a/test/game/command/look_test.exs
+++ b/test/game/command/look_test.exs
@@ -8,8 +8,6 @@ defmodule Game.Command.LookTest do
 
   doctest Look
 
-  @room Test.Game.Room
-
   describe "normal room" do
     setup do
       start_and_clear_items()
@@ -33,7 +31,7 @@ defmodule Game.Command.LookTest do
         features: [%{key: "log", short_description: "log", description: "a log"}],
         zone: %{id: 10, name: "Zone"}
       }
-      @room.set_room(Map.merge(@room._room(), room))
+      start_room(room)
 
       user = create_user(%{name: "hero", password: "password"})
       character = create_character(user, %{name: "hero"})
@@ -48,7 +46,7 @@ defmodule Game.Command.LookTest do
     end
 
     test "view room information - the room is offline", %{state: state} do
-      @room.set_room(:offline)
+      mark_room_offline()
 
       {:error, :room_offline} = Look.run({}, state)
 
@@ -74,6 +72,8 @@ defmodule Game.Command.LookTest do
     end
 
     test "looking in a direction", %{state: state} do
+      start_room(%{id: 2, name: "Hallway"})
+
       :ok = Look.run({:direction, "north"}, state)
 
       assert_socket_echo "hallway"
@@ -98,7 +98,7 @@ defmodule Game.Command.LookTest do
         id: "overworld:1:1,1",
         exits: [%Exit{has_door: false, direction: "west"}],
       }
-      @room.set_room(room)
+      start_overworld_room(room)
 
       user = create_user(%{name: "hero", password: "password"})
       character = create_character(user, %{name: "hero"})

--- a/test/game/command/look_test.exs
+++ b/test/game/command/look_test.exs
@@ -98,7 +98,7 @@ defmodule Game.Command.LookTest do
         id: "overworld:1:1,1",
         exits: [%Exit{has_door: false, direction: "west"}],
       }
-      start_overworld_room(room)
+      start_room(room)
 
       user = create_user(%{name: "hero", password: "password"})
       character = create_character(user, %{name: "hero"})

--- a/test/game/command/map_test.exs
+++ b/test/game/command/map_test.exs
@@ -5,10 +5,8 @@ defmodule Game.Command.MapTest do
 
   doctest Map
 
-  @room Test.Game.Room
-
   setup do
-    @room.set_room(@room._room())
+    start_room(%{})
     %{socket: :socket}
   end
 

--- a/test/game/command/quest_test.exs
+++ b/test/game/command/quest_test.exs
@@ -6,7 +6,6 @@ defmodule Game.Command.QuestTest do
 
   doctest Quest
 
-  @room Test.Game.Room
   @npc Test.Game.NPC
 
   setup do
@@ -96,10 +95,7 @@ defmodule Game.Command.QuestTest do
       guard = Map.put(guard, :original_id, guard.id)
       quest = create_quest(guard, %{name: "Into the Dungeon", experience: 200, currency: 25})
 
-      room = Map.merge(@room._room(), %{
-        npcs: [Character.Simple.from_npc(guard)],
-      })
-      @room.set_room(room)
+      start_room(%{npcs: [Character.Simple.from_npc(guard)]})
       @npc.clear_notifies()
 
       state = state |> Map.put(:save, %{state.save | room_id: 1, level: 1, experience_points: 20, currency: 15})
@@ -135,7 +131,7 @@ defmodule Game.Command.QuestTest do
       goblin = create_npc(%{name: "Goblin"})
       npc_step = create_quest_step(quest, %{type: "npc/kill", count: 3, npc_id: goblin.id})
       create_quest_progress(state.character, quest, %{progress: %{npc_step.id => 3}})
-      @room.set_room(Map.merge(@room._room(), %{npcs: []}))
+      start_room(%{npcs: []})
 
       :ok = Quest.run({:complete, to_string(quest.id)}, state)
 
@@ -204,10 +200,7 @@ defmodule Game.Command.QuestTest do
       guard = Map.put(guard, :original_id, guard.id)
       quest = create_quest(guard, %{name: "Into the Dungeon", experience: 200, currency: 25})
 
-      room = Map.merge(@room._room(), %{
-        npcs: [Character.Simple.from_npc(guard)],
-      })
-      @room.set_room(room)
+      start_room(%{npcs: [Character.Simple.from_npc(guard)]})
       @npc.clear_notifies()
 
       state = state |> Map.put(:save, %{state.save | room_id: 1, level: 1, experience_points: 20, currency: 15})
@@ -237,7 +230,7 @@ defmodule Game.Command.QuestTest do
 
     test "handles no npc in the room to hand in to", %{state: state, quest: quest} do
       create_quest_progress(state.character, quest)
-      @room.set_room(Map.merge(@room._room(), %{npcs: []}))
+      start_room(%{npcs: []})
 
       :ok = Quest.run({:complete, :any}, state)
 

--- a/test/game/command/recall_test.exs
+++ b/test/game/command/recall_test.exs
@@ -5,18 +5,18 @@ defmodule Game.Command.RecallTest do
 
   doctest Recall
 
-  @room Test.Game.Room
   @zone Test.Game.Zone
 
   setup do
     user = create_user(%{name: "user", password: "password"})
     character = create_character(user)
+
     %{state: session_state(%{user: user, character: character, save: character.save})}
   end
 
   describe "recalling to a graveyard" do
     test "teleports to the zone's graveyard", %{state: state} do
-      @room.set_room(@room._room())
+      start_room(%{})
       @zone.set_graveyard({:ok, 2})
 
       {:update, state} = Recall.run({}, state)
@@ -36,7 +36,7 @@ defmodule Game.Command.RecallTest do
     end
 
     test "zone does not have a graveyard", %{state: state} do
-      @room.set_room(@room._room())
+      start_room(%{})
       @zone.set_graveyard({:error, :no_graveyard})
 
       :ok = Recall.run({}, state)

--- a/test/game/command/run_test.exs
+++ b/test/game/command/run_test.exs
@@ -7,8 +7,6 @@ defmodule Game.Command.RunTest do
 
   doctest Run
 
-  @room Test.Game.Room
-
   setup do
     room = %Game.Environment.State.Room{
       id: 1,
@@ -19,7 +17,8 @@ defmodule Game.Command.RunTest do
       shops: [],
       zone: %{id: 10, name: "Zone"}
     }
-    @room.set_room(room)
+    start_room(room)
+    start_room(%{id: 2})
 
     user = base_user()
     character = base_character(user)

--- a/test/game/command/say_test.exs
+++ b/test/game/command/say_test.exs
@@ -6,8 +6,6 @@ defmodule Game.Command.SayTest do
 
   doctest Say
 
-  @room Test.Game.Room
-
   setup do
     user = create_user(%{name: "user", password: "password"})
     character = create_character(user)
@@ -33,7 +31,7 @@ defmodule Game.Command.SayTest do
   describe "say to someone" do
     test "to a player", %{state: state} do
       player = %{id: 1, name: "Player"}
-      @room.set_room(Map.merge(@room._room(), %{players: [player]}))
+      start_room(%{players: [player]})
 
       :ok = Say.run({">player hi"}, state)
 
@@ -42,7 +40,7 @@ defmodule Game.Command.SayTest do
 
     test "to an npc", %{state: state} do
       guard = create_npc(%{name: "Guard"})
-      @room.set_room(Map.merge(@room._room(), %{npcs: [guard]}))
+      start_room(%{npcs: [guard]})
 
       :ok = Say.run({">guard hi"}, state)
 
@@ -50,7 +48,7 @@ defmodule Game.Command.SayTest do
     end
 
     test "target not found", %{state: state} do
-      @room.set_room(@room._room())
+      start_room(%{})
 
       :ok = Say.run({">guard hi"}, state)
 

--- a/test/game/command/scan_test.exs
+++ b/test/game/command/scan_test.exs
@@ -6,14 +6,6 @@ defmodule Game.Command.ScanTest do
 
   doctest Scan
 
-  @room Test.Game.Room
-
-  @basic_room %Game.Environment.State.Room{
-    name: "Room",
-    players: [],
-    npcs: []
-  }
-
   setup do
     user = create_user(%{name: "user", password: "password"})
     character = create_character(user)
@@ -32,26 +24,22 @@ defmodule Game.Command.ScanTest do
       north_exit = %{id: 4, has_door: true, door_id: 4, direction: "north", start_id: 1, finish_id: 2}
       in_exit = %{id: 5, has_door: true, door_id: 5, direction: "in", start_id: 1, finish_id: 3}
 
-      room =
-        Map.merge(@basic_room, %{
-          id: 1,
-          exits: [north_exit, in_exit],
-          npcs: [%{id: 1, name: "Bandit"}],
-        })
-
       Door.set(north_exit, "open")
       Door.set(in_exit, "closed")
 
-      @room.set_room(room, multiple: true)
-
-      @room.set_room(Map.merge(@basic_room, %{
+      start_room(%{
+        id: 1,
+        exits: [north_exit, in_exit],
+        npcs: [%{id: 1, name: "Bandit"}],
+      })
+      start_room(%{
         id: 2,
         players: [%{id: 1, name: "Player"}],
-      }), multiple: true)
-      @room.set_room(Map.merge(@basic_room, %{
+      })
+      start_room(%{
         id: 3,
         npcs: [%{id: 1, name: "Guard"}],
-      }), multiple: true)
+      })
 
       :ok
     end

--- a/test/game/command/shops_test.exs
+++ b/test/game/command/shops_test.exs
@@ -1,7 +1,6 @@
 defmodule Game.Command.ShopsTest do
   use ExVenture.CommandCase
 
-  @room Test.Game.Room
   @shop Test.Game.Shop
 
   alias Game.Command.Shops
@@ -15,15 +14,14 @@ defmodule Game.Command.ShopsTest do
 
     tree_stand = %{id: 10, name: "Tree Stand Shop", shop_items: [%{item_id: 1, price: 10, quantity: -1}]}
     hole_wall = %{id: 11, name: "Hole in the Wall"}
-    room = %{@room._room() | shops: [tree_stand, hole_wall]}
+    start_room(%{shops: [tree_stand, hole_wall]})
 
-    @room.set_room(room)
     @shop.set_shop(tree_stand)
 
     @shop.clear_buys()
     @shop.clear_sells()
 
-    {:ok, %{state: session_state(%{}), room: room, tree_stand: tree_stand}}
+    %{state: session_state(%{}), tree_stand: tree_stand}
   end
 
   test "a bad shop command displays help", %{state: state} do
@@ -39,8 +37,7 @@ defmodule Game.Command.ShopsTest do
   end
 
   test "view shops in the room - overworld", %{state: state} do
-    room = %Overworld{id: "overworld:1:1,1"}
-    @room.set_room(room)
+    start_room(%Overworld{id: "overworld:1:1,1"})
 
     :ok = Shops.run({}, %{state | save: %{room_id: "overworld:1:1,1"}})
 
@@ -48,8 +45,7 @@ defmodule Game.Command.ShopsTest do
   end
 
   test "view shops in the room - no shops", %{state: state} do
-    room = %{@room._room() | shops: []}
-    @room.set_room(room)
+    start_room(%{shops: []})
 
     :ok = Shops.run({}, %{state | save: %{room_id: 1}})
 
@@ -62,9 +58,8 @@ defmodule Game.Command.ShopsTest do
     assert_socket_echo ["tree stand shop", "sword"]
   end
 
-  test "view items in a shop - one shop", %{state: state, room: room, tree_stand: tree_stand} do
-    room = %{room | shops: [tree_stand]}
-    @room.set_room(room)
+  test "view items in a shop - one shop", %{state: state, tree_stand: tree_stand} do
+    start_room(%{shops: [tree_stand]})
 
     :ok = Shops.run({:list}, %{state | save: %{room_id: 1}})
 
@@ -77,9 +72,8 @@ defmodule Game.Command.ShopsTest do
     assert_socket_echo "more than one shop"
   end
 
-  test "view items in a shop - one shop - no shop found", %{state: state, room: room} do
-    room = %{room | shops: []}
-    @room.set_room(room)
+  test "view items in a shop - one shop - no shop found", %{state: state} do
+    start_room(%{shops: []})
 
     :ok = Shops.run({:list}, %{state | save: %{room_id: 1}})
 
@@ -104,9 +98,8 @@ defmodule Game.Command.ShopsTest do
     assert_socket_echo "could not"
   end
 
-  test "view an item in a shop - one shop", %{state: state, room: room, tree_stand: tree_stand} do
-    room = %{room | shops: [tree_stand]}
-    @room.set_room(room)
+  test "view an item in a shop - one shop", %{state: state, tree_stand: tree_stand} do
+    start_room(%{shops: [tree_stand]})
 
     :ok = Shops.run({:show, "sword"}, %{state | save: %{room_id: 1}})
 
@@ -119,9 +112,8 @@ defmodule Game.Command.ShopsTest do
     assert_socket_echo "more than one shop"
   end
 
-  test "view an item in a shop - one shop - no shop found", %{state: state, room: room} do
-    room = %{room | shops: []}
-    @room.set_room(room)
+  test "view an item in a shop - one shop - no shop found", %{state: state} do
+    start_room(%{shops: []})
 
     :ok = Shops.run({:show, "sword"}, %{state | save: %{room_id: 1}})
 
@@ -155,9 +147,8 @@ defmodule Game.Command.ShopsTest do
     assert_socket_echo "could not"
   end
 
-  test "buy an item in a shop - one shop", %{state: state, room: room, tree_stand: tree_stand} do
-    room = %{room | shops: [tree_stand]}
-    @room.set_room(room)
+  test "buy an item in a shop - one shop", %{state: state, tree_stand: tree_stand} do
+    start_room(%{shops: [tree_stand]})
 
     save = %{base_save() | room_id: 1, currency: 20}
     @shop.set_buy({:ok, %{save | currency: 19}, %{name: "Sword"}})
@@ -179,9 +170,8 @@ defmodule Game.Command.ShopsTest do
     assert_socket_echo "more than one"
   end
 
-  test "buy an item in a shop - one shop parse - no shop in room", %{state: state, room: room} do
-    room = %{room | shops: []}
-    @room.set_room(room)
+  test "buy an item in a shop - one shop parse - no shop in room", %{state: state} do
+    start_room(%{shops: []})
 
     save = %{base_save() | room_id: 1, currency: 20}
     :ok = Shops.run({:buy, "sword"}, %{state | save: save})
@@ -236,9 +226,8 @@ defmodule Game.Command.ShopsTest do
     assert_socket_echo "10 gold"
   end
 
-  test "sell an item to a shop - one shop", %{state: state, room: room, tree_stand: tree_stand} do
-    room = %{room | shops: [tree_stand]}
-    @room.set_room(room)
+  test "sell an item to a shop - one shop", %{state: state, tree_stand: tree_stand} do
+    start_room(%{shops: [tree_stand]})
 
     save = %{base_save() | room_id: 1, currency: 20, items: [item_instance(1)]}
     @shop.set_sell({:ok, %{save | currency: 30}, %{name: "Sword", cost: 10}})
@@ -260,9 +249,8 @@ defmodule Game.Command.ShopsTest do
     assert_socket_echo "more than one"
   end
 
-  test "sell an item in a shop - one shop parse - no shop in room", %{state: state, room: room} do
-    room = %{room | shops: []}
-    @room.set_room(room)
+  test "sell an item in a shop - one shop parse - no shop in room", %{state: state} do
+    start_room(%{shops: []})
 
     save = %{base_save() | room_id: 1, currency: 20}
     :ok = Shops.run({:sell, "sword"}, %{state | save: save})

--- a/test/game/command/skills_test.exs
+++ b/test/game/command/skills_test.exs
@@ -7,8 +7,6 @@ defmodule Game.Command.SkillsTest do
 
   doctest Skills
 
-  @room Test.Game.Room
-
   setup do
     start_and_clear_skills()
 
@@ -30,12 +28,7 @@ defmodule Game.Command.SkillsTest do
     save = %{base_save() | level: 1, stats: %{health_points: 20, strength: 10, skill_points: 10}, wearing: %{}, skill_ids: [slash.id]}
     character = %{base_character(user) | save: save}
 
-    room =
-      @room._room()
-      |> Map.put(:npcs, [npc])
-      |> Map.put(:players, [user])
-
-    @room.set_room(room)
+    start_room(%{npcs: [npc], players: [user]})
 
     state = session_state(%{
       skills: %{},

--- a/test/game/command/socials_test.exs
+++ b/test/game/command/socials_test.exs
@@ -8,8 +8,6 @@ defmodule Game.Command.SocialsTest do
 
   doctest Socials
 
-  @room Test.Game.Room
-
   setup do
     start_and_clear_socials()
 
@@ -70,7 +68,7 @@ defmodule Game.Command.SocialsTest do
   describe "using a social" do
     test "with a target", %{state: state} do
       guard = create_npc(%{name: "Guard"})
-      @room.set_room(Map.merge(@room._room(), %{npcs: [guard]}))
+      start_room(%{npcs: [guard]})
 
       :ok = Socials.run({"smile", "guard"}, state)
 
@@ -78,7 +76,7 @@ defmodule Game.Command.SocialsTest do
     end
 
     test "with a target - target not found", %{state: state} do
-      @room.set_room(@room._room())
+      start_room(%{})
 
       :ok = Socials.run({"smile", "guard"}, state)
 

--- a/test/game/command/target_test.exs
+++ b/test/game/command/target_test.exs
@@ -5,19 +5,17 @@ defmodule Game.Command.TargetTest do
 
   doctest Target
 
-  @room Test.Game.Room
-
   setup do
     npc = %{id: 1, name: "Bandit"}
 
-    room = @room._room()
-    |> Map.put(:npcs, [npc])
-    |> Map.put(:players, [%{id: 2, name: "Player", save: %{stats: %{health_points: 1}}}])
-
-    @room.set_room(room)
+    start_room(%{
+      npcs: [npc],
+      players: [%{id: 2, name: "Player", save: %{stats: %{health_points: 1}}}]
+    })
 
     user = base_user()
     character = base_character(user)
+
     %{state: session_state(%{user: user, character: character})}
   end
 
@@ -49,10 +47,10 @@ defmodule Game.Command.TargetTest do
   end
 
   test "cannot target another player if health is < 1", %{state: state} do
-    room = @room._room()
-    |> Map.put(:npcs, [])
-    |> Map.put(:players, [%{id: 2, name: "Player", save: %{stats: %{health_points: -1}}}])
-    @room.set_room(room)
+    start_room(%{
+      npcs: [],
+      players: [%{id: 2, name: "Player", save: %{stats: %{health_points: -1}}}]
+    })
 
     :ok = Game.Command.Target.run({:set, "player"}, state)
 

--- a/test/game/command/tell_test.exs
+++ b/test/game/command/tell_test.exs
@@ -8,14 +8,11 @@ defmodule Game.Command.TellTest do
 
   doctest Tell
 
-  @room Test.Game.Room
-
   setup do
-    @room.set_room(Map.merge(@room._room(), %{npcs: []}))
-
     user = base_user()
     character = base_character(user)
     save = %{character.save | room_id: 1}
+
     %{state: session_state(%{user: user, character: character, save: save})}
   end
 
@@ -31,6 +28,8 @@ defmodule Game.Command.TellTest do
     end
 
     test "send a tell - player not found", %{state: state} do
+      start_room(%{})
+
       :ok = Tell.run({"tell", "player hello"}, state)
 
       assert_socket_echo "not online"
@@ -42,7 +41,7 @@ defmodule Game.Command.TellTest do
       npc = create_npc(%{name: "Guard"})
 
       room = %{id: 1, npcs: [npc]}
-      @room.set_room(Map.merge(@room._room(), room))
+      start_room(room)
 
       %{npc: npc, state: %{state | save: %{room_id: room.id}, reply_to: {:npc, npc}}}
     end
@@ -56,8 +55,7 @@ defmodule Game.Command.TellTest do
     end
 
     test "send a tell - npc not in the room", %{state: state} do
-      room = %{id: 1, npcs: []}
-      @room.set_room(Map.merge(@room._room(), room))
+      start_room(%{npcs: []})
 
       :ok = Tell.run({"tell", "guard howdy"}, state)
 
@@ -94,7 +92,7 @@ defmodule Game.Command.TellTest do
       npc = create_npc()
 
       room = %{id: 1, npcs: [npc]}
-      @room.set_room(Map.merge(@room._room(), room))
+      start_room(room)
 
       %{npc: npc, state: %{state | save: %{room_id: room.id}, reply_to: {:npc, npc}}}
     end
@@ -108,8 +106,7 @@ defmodule Game.Command.TellTest do
     end
 
     test "send a reply - npc not in the room", %{state: state} do
-      room = %{id: 1, npcs: []}
-      @room.set_room(Map.merge(@room._room(), room))
+      start_room(%{id: 1, npcs: []})
 
       :ok = Tell.run({"reply", "howdy"}, state)
 

--- a/test/game/command/train_test.exs
+++ b/test/game/command/train_test.exs
@@ -7,8 +7,6 @@ defmodule Game.Command.TrainTest do
 
   doctest Train
 
-  @room Test.Game.Room
-
   setup do
     user = create_user(%{name: "user", password: "password"})
     character = create_character(user)
@@ -23,7 +21,7 @@ defmodule Game.Command.TrainTest do
     end
 
     test "one npc in the room", %{state: state, guard: guard} do
-      @room.set_room(Map.merge(@room._room(), %{npcs: [guard]}))
+      start_room(%{npcs: [guard]})
 
       :ok = Train.run({:list}, state)
 
@@ -38,7 +36,7 @@ defmodule Game.Command.TrainTest do
 
       guard = %{guard | extra: %{guard.extra | trainable_skills: [slash.id, kick.id]}}
 
-      @room.set_room(Map.merge(@room._room(), %{npcs: [guard]}))
+      start_room(%{npcs: [guard]})
 
       state = %{state | save: %{state.save | skill_ids: [slash.id]}}
 
@@ -55,7 +53,7 @@ defmodule Game.Command.TrainTest do
 
       guard = %{guard | extra: %{guard.extra | trainable_skills: [slash.id, kick.id]}}
 
-      @room.set_room(Map.merge(@room._room(), %{npcs: [guard]}))
+      start_room(%{npcs: [guard]})
 
       state = %{state | save: %{state.save | level: 2}}
 
@@ -65,7 +63,7 @@ defmodule Game.Command.TrainTest do
     end
 
     test "no trainers in the room", %{state: state} do
-      @room.set_room(Map.merge(@room._room(), %{npcs: []}))
+      start_room(%{npcs: []})
 
       :ok = Train.run({:list}, state)
 
@@ -75,7 +73,7 @@ defmodule Game.Command.TrainTest do
     test "more than one trainer", %{state: state, guard: guard} do
       master = create_npc(%{name: "Guard", is_trainer: true})
       master = Character.Simple.from_npc(master)
-      @room.set_room(Map.merge(@room._room(), %{npcs: [guard, master]}))
+      start_room(%{npcs: [guard, master]})
 
       :ok = Train.run({:list}, state)
 
@@ -84,7 +82,7 @@ defmodule Game.Command.TrainTest do
 
     test "more than one trainer - by name", %{state: state, guard: guard} do
       master = create_npc(%{name: "Guard", is_trainer: true})
-      @room.set_room(Map.merge(@room._room(), %{npcs: [guard, master]}))
+      start_room(%{npcs: [guard, master]})
 
       :ok = Train.run({:list, "guard"}, state)
 
@@ -92,7 +90,7 @@ defmodule Game.Command.TrainTest do
     end
 
     test "trainer not found - by name", %{state: state} do
-      @room.set_room(Map.merge(@room._room(), %{npcs: []}))
+      start_room(%{npcs: []})
 
       :ok = Train.run({:list, "guard"}, state)
 
@@ -113,7 +111,7 @@ defmodule Game.Command.TrainTest do
     end
 
     test "training a skill", %{state: state, guard: guard, slash: slash} do
-      @room.set_room(Map.merge(@room._room(), %{npcs: [guard]}))
+      start_room(%{npcs: [guard]})
 
       {:update, state} = Train.run({:train, "slash"}, state)
 
@@ -125,7 +123,7 @@ defmodule Game.Command.TrainTest do
     end
 
     test "skill not found", %{state: state, guard: guard} do
-      @room.set_room(Map.merge(@room._room(), %{npcs: [guard]}))
+      start_room(%{npcs: [guard]})
 
       :ok = Train.run({:train, "kick"}, state)
 
@@ -133,7 +131,7 @@ defmodule Game.Command.TrainTest do
     end
 
     test "skill already known", %{state: state, guard: guard, slash: slash} do
-      @room.set_room(Map.merge(@room._room(), %{npcs: [guard]}))
+      start_room(%{npcs: [guard]})
       state = %{state | save: %{state.save | skill_ids: [slash.id]}}
 
       :ok = Train.run({:train, "slash"}, state)
@@ -144,7 +142,7 @@ defmodule Game.Command.TrainTest do
     test "not high enough level", %{state: state, guard: guard, slash: slash} do
       slash |> Map.put(:level, 4) |> insert_skill()
 
-      @room.set_room(Map.merge(@room._room(), %{npcs: [guard]}))
+      start_room(%{npcs: [guard]})
       state = %{state | save: %{state.save | level: 3}}
 
       :ok = Train.run({:train, "slash"}, state)
@@ -153,7 +151,7 @@ defmodule Game.Command.TrainTest do
     end
 
     test "not enough xp left to spend", %{state: state, guard: guard} do
-      @room.set_room(Map.merge(@room._room(), %{npcs: [guard]}))
+      start_room(%{npcs: [guard]})
       state = %{state | save: %{state.save | spent_experience_points: 900, experience_points: 1000}}
 
       :ok = Train.run({:train, "slash"}, state)
@@ -162,7 +160,7 @@ defmodule Game.Command.TrainTest do
     end
 
     test "no trainers in the room", %{state: state} do
-      @room.set_room(Map.merge(@room._room(), %{npcs: []}))
+      start_room(%{npcs: []})
 
       :ok = Train.run({:train, "slash"}, state)
 
@@ -172,7 +170,7 @@ defmodule Game.Command.TrainTest do
     test "more than one trainer", %{state: state, guard: guard} do
       master = create_npc(%{name: "Guard", is_trainer: true})
       master = Character.Simple.from_npc(master)
-      @room.set_room(Map.merge(@room._room(), %{npcs: [guard, master]}))
+      start_room(%{npcs: [guard, master]})
 
       :ok = Train.run({:train, "slash"}, state)
 
@@ -180,7 +178,7 @@ defmodule Game.Command.TrainTest do
     end
 
     test "more than one trainer - by name", %{state: state, guard: guard, slash: slash} do
-      @room.set_room(Map.merge(@room._room(), %{npcs: [guard]}))
+      start_room(%{npcs: [guard]})
 
       {:update, state} = Train.run({:train, "slash", :from, "guard"}, state)
 
@@ -190,7 +188,7 @@ defmodule Game.Command.TrainTest do
     end
 
     test "trainer not found - by name", %{state: state, guard: guard} do
-      @room.set_room(Map.merge(@room._room(), %{npcs: [guard]}))
+      start_room(%{npcs: [guard]})
 
       :ok = Train.run({:train, "slash", :from, "unknown"}, state)
 

--- a/test/game/command/whisper_test.exs
+++ b/test/game/command/whisper_test.exs
@@ -5,8 +5,6 @@ defmodule Game.Command.WhisperTest do
 
   doctest Whisper
 
-  @room Test.Game.Room
-
   setup do
     user = create_user(%{name: "user", password: "password"})
     character = create_character(user)
@@ -16,7 +14,7 @@ defmodule Game.Command.WhisperTest do
   describe "whisper to someone" do
     test "to a player", %{state: state} do
       player = %{id: 1, name: "Player"}
-      @room.set_room(Map.merge(@room._room(), %{players: [player]}))
+      start_room(%{players: [player]})
 
       :ok = Whisper.run({:whisper, "player hi"}, state)
 
@@ -25,7 +23,7 @@ defmodule Game.Command.WhisperTest do
 
     test "to an npc", %{state: state} do
       guard = create_npc(%{name: "Guard"})
-      @room.set_room(Map.merge(@room._room(), %{npcs: [guard]}))
+      start_room(%{npcs: [guard]})
 
       :ok = Whisper.run({:whisper, "guard hi"}, state)
 
@@ -33,7 +31,7 @@ defmodule Game.Command.WhisperTest do
     end
 
     test "target not found", %{state: state} do
-      @room.set_room(@room._room())
+      start_room(%{})
 
       :ok = Whisper.run({:whisper, "guard hi"}, state)
 

--- a/test/game/npc/actions/commands_emote_test.exs
+++ b/test/game/npc/actions/commands_emote_test.exs
@@ -1,17 +1,12 @@
 defmodule Game.NPC.Actions.CommandsEmoteTest do
-  use Data.ModelCase
+  use ExVenture.NPCCase
 
   alias Data.Events.Actions
   alias Game.NPC.Actions.CommandsEmote
-  alias Game.NPC.State
 
   doctest CommandsEmote
 
-  @room Test.Game.Room
-
   setup do
-    @room.clear_emotes()
-
     npc = npc_attributes(%{
       id: 1,
       status_line: "[name] is here.",
@@ -29,8 +24,7 @@ defmodule Game.NPC.Actions.CommandsEmoteTest do
 
       {:ok, ^state} = CommandsEmote.act(state, action)
 
-      [{_, message}] = @room.get_emotes()
-      assert message.message == "Hello"
+      assert_emote "hello"
     end
 
     test "handles status updates", %{state: state} do

--- a/test/game/npc/actions/commands_move_test.exs
+++ b/test/game/npc/actions/commands_move_test.exs
@@ -8,8 +8,6 @@ defmodule Game.NPC.Actions.CommandsMoveTest do
 
   doctest CommandsMove
 
-  @room Test.Game.Room
-
   setup [:basic_setup]
 
   describe "acting" do
@@ -25,11 +23,7 @@ defmodule Game.NPC.Actions.CommandsMoveTest do
     test "does not move if a door is closed", %{state: state, action: action} do
       room_exit = %{id: 10, direction: "north", start_id: 1, finish_id: 2, has_door: true, door_id: 10}
 
-      @room._room()
-      |> Map.put(:id, 1)
-      |> Map.put(:y, 1)
-      |> Map.put(:exits, [room_exit])
-      |> @room.set_room(multiple: true)
+      start_room(%{id: 1, y: 1, exits: [room_exit]})
 
       Door.load(room_exit)
       Door.set(room_exit, "closed")
@@ -60,11 +54,8 @@ defmodule Game.NPC.Actions.CommandsMoveTest do
     end
 
     test "does not move if going past the maximum distance", %{state: state, action: action} do
-      @room._room()
-      |> Map.put(:id, 2)
-      |> Map.put(:y, 7)
-      |> Map.put(:exits, [%{direction: "south", start_id: 2, finish_id: 1, has_door: false}])
-      |> @room.set_room(multiple: true)
+      room_exit = %{direction: "south", start_id: 2, finish_id: 1, has_door: false}
+      start_room(%{id: 2, y: 7, exits: [room_exit]})
 
       {:ok, state} = CommandsMove.act(state, action)
 
@@ -75,10 +66,7 @@ defmodule Game.NPC.Actions.CommandsMoveTest do
     end
 
     test "does not move into a new zone", %{state: state, action: action} do
-      @room._room()
-      |> Map.put(:id, 2)
-      |> Map.put(:zone_id, 2)
-      |> @room.set_room(multiple: true)
+      start_room(%{id: 2, zone_id: 2})
 
       {:ok, state} = CommandsMove.act(state, action)
 
@@ -98,17 +86,11 @@ defmodule Game.NPC.Actions.CommandsMoveTest do
       npc_spawner: %{room_id: 1}
     }
 
-    @room._room()
-    |> Map.put(:id, 1)
-    |> Map.put(:y, 1)
-    |> Map.put(:exits, [%{direction: "north", start_id: 1, finish_id: 2, has_door: false}])
-    |> @room.set_room(multiple: true)
+    room_exit = %{direction: "north", start_id: 1, finish_id: 2, has_door: false}
+    start_room(%{id: 1, y: 1, exits: [room_exit]})
 
-    @room._room()
-    |> Map.put(:id, 2)
-    |> Map.put(:y, 0)
-    |> Map.put(:exits, [%{direction: "south", start_id: 2, finish_id: 1, has_door: false}])
-    |> @room.set_room(multiple: true)
+    room_exit = %{direction: "south", start_id: 2, finish_id: 1, has_door: false}
+    start_room(%{id: 2, y: 0, exits: [room_exit]})
 
     start_and_clear_doors()
 

--- a/test/game/npc/actions/commands_move_test.exs
+++ b/test/game/npc/actions/commands_move_test.exs
@@ -1,5 +1,5 @@
 defmodule Game.NPC.Actions.CommandsMoveTest do
-  use Data.ModelCase
+  use ExVenture.NPCCase
 
   alias Data.Events.Actions
   alias Game.Door
@@ -18,8 +18,8 @@ defmodule Game.NPC.Actions.CommandsMoveTest do
 
       assert state.room_id == 2
 
-      assert [{2, {:npc, _npc}, _reason}] = @room.get_enters()
-      assert [{1, {:npc, _npc}, _reason}] = @room.get_leaves()
+      assert_enter {2, {:npc, _}, _}
+      assert_leave {1, {:npc, _}, _}
     end
 
     test "does not move if a door is closed", %{state: state, action: action} do
@@ -38,8 +38,8 @@ defmodule Game.NPC.Actions.CommandsMoveTest do
 
       assert state.room_id == 1
 
-      assert [] = @room.get_enters()
-      assert [] = @room.get_leaves()
+      refute_enter()
+      refute_leave()
     end
 
     test "does not move when a target is present", %{state: state, action: action} do
@@ -70,8 +70,8 @@ defmodule Game.NPC.Actions.CommandsMoveTest do
 
       assert state.room_id == 1
 
-      assert [] = @room.get_enters()
-      assert [] = @room.get_leaves()
+      refute_enter()
+      refute_leave()
     end
 
     test "does not move into a new zone", %{state: state, action: action} do
@@ -84,15 +84,12 @@ defmodule Game.NPC.Actions.CommandsMoveTest do
 
       assert state.room_id == 1
 
-      assert [] = @room.get_enters()
-      assert [] = @room.get_leaves()
+      refute_enter()
+      refute_leave()
     end
   end
 
   def basic_setup(_) do
-    @room.clear_enters()
-    @room.clear_leaves()
-
     npc = npc_attributes(%{id: 1})
 
     state = %State{

--- a/test/game/npc/actions/commands_say_test.exs
+++ b/test/game/npc/actions/commands_say_test.exs
@@ -1,16 +1,12 @@
 defmodule Game.NPC.Actions.CommandsSayTest do
-  use Data.ModelCase
+  use ExVenture.NPCCase
 
   alias Data.Events.Actions
   alias Game.NPC.Actions.CommandsSay
 
   doctest CommandsSay
 
-  @room Test.Game.Room
-
   setup do
-    @room.clear_says()
-
     %{state: %{npc: npc_attributes(%{id: 1}), room_id: 1}}
   end
 
@@ -22,8 +18,7 @@ defmodule Game.NPC.Actions.CommandsSayTest do
 
       {:ok, ^state} = CommandsSay.act(state, action)
 
-      [{_, message}] = @room.get_says()
-      assert message.message == "Hello"
+      assert_say "hello"
     end
 
     test "selects a random message", %{state: state} do
@@ -33,8 +28,7 @@ defmodule Game.NPC.Actions.CommandsSayTest do
 
       {:ok, ^state} = CommandsSay.act(state, action)
 
-      [{_, message}] = @room.get_says()
-      assert message.message == "Hello"
+      assert_say "hello"
     end
   end
 
@@ -49,8 +43,7 @@ defmodule Game.NPC.Actions.CommandsSayTest do
 
       {:ok, ^state} = CommandsSay.act(state, action)
 
-      [{_, message}] = @room.get_says()
-      assert message.message == "Hello"
+      assert_say "hello"
     end
 
     test "when does not matches", %{state: state} do
@@ -63,7 +56,7 @@ defmodule Game.NPC.Actions.CommandsSayTest do
 
       {:ok, ^state} = CommandsSay.act(state, action)
 
-      assert @room.get_says() == []
+      refute_say()
     end
   end
 end

--- a/test/game/npc/actions/commands_skill_test.exs
+++ b/test/game/npc/actions/commands_skill_test.exs
@@ -1,5 +1,5 @@
 defmodule Game.NPC.Actions.CommandsSkillTest do
-  use Data.ModelCase
+  use ExVenture.NPCCase
 
   alias Data.Events.Actions
   alias Game.Character
@@ -8,8 +8,6 @@ defmodule Game.NPC.Actions.CommandsSkillTest do
   alias Game.Session.Registry
 
   doctest CommandsSkill
-
-  @room Test.Game.Room
 
   setup [:basic_setup]
 
@@ -41,9 +39,7 @@ defmodule Game.NPC.Actions.CommandsSkillTest do
     end
 
     test "with target not in the room", %{state: state, action: action, player: player} do
-      @room._room()
-      |> Map.put(:players, [])
-      |> @room.set_room()
+      start_room(%{players: []})
 
       state = %{state | combat: true, target: {:player, player}}
 
@@ -73,9 +69,7 @@ defmodule Game.NPC.Actions.CommandsSkillTest do
     Registry.register(notify_character)
     Registry.catch_up()
 
-    @room._room()
-    |> Map.put(:players, [player])
-    |> @room.set_room()
+    start_room(%{players: [player]})
 
     start_and_clear_skills()
     insert_skill(create_skill(%{command: "slash"}))

--- a/test/game/npc/actions_test.exs
+++ b/test/game/npc/actions_test.exs
@@ -23,7 +23,7 @@ defmodule Game.NPC.ActionsTest do
     test "no more actions" do
       Actions.delay([])
 
-      refute_receive {:delayed_actions, []}
+      refute_received {:delayed_actions, []}
     end
   end
 
@@ -46,7 +46,7 @@ defmodule Game.NPC.ActionsTest do
 
       {:ok, ^state} = Actions.process(state, [])
 
-      refute_receive {:delayed_actions, []}
+      refute_received {:delayed_actions, []}
     end
   end
 

--- a/test/game/npc/character_test.exs
+++ b/test/game/npc/character_test.exs
@@ -40,6 +40,8 @@ defmodule Game.NPC.CharacterTest do
     end
 
     test "respawns the npc", %{state: state, npc: npc} do
+      start_room(%{id: 1})
+
       state = %{state | npc: put_in(npc, [:stats, :health_points], 0)}
 
       state = Character.handle_respawn(state)

--- a/test/game/npc/character_test.exs
+++ b/test/game/npc/character_test.exs
@@ -174,7 +174,7 @@ defmodule Game.NPC.CharacterTest do
 
       effect_id = effect.id
       assert [] = state.continuous_effects
-      refute_receive {:continuous_effect, ^effect_id}
+      refute_received {:continuous_effect, ^effect_id}
     end
 
     test "does nothing if effect is not found", %{state: state} do

--- a/test/game/npc/events/room_heard_test.exs
+++ b/test/game/npc/events/room_heard_test.exs
@@ -36,7 +36,7 @@ defmodule Game.NPC.Events.RoomHeardTest do
 
       {:ok, ^state} = RoomHeard.process(state, sent_event)
 
-      refute_receive {:delayed_actions, [_]}
+      refute_received {:delayed_actions, [_]}
     end
   end
 

--- a/test/game/npc/events_test.exs
+++ b/test/game/npc/events_test.exs
@@ -1,5 +1,5 @@
 defmodule Game.NPC.EventsTest do
-  use Data.ModelCase
+  use ExVenture.NPCCase
 
   import Test.DamageTypesHelper
 
@@ -14,9 +14,6 @@ defmodule Game.NPC.EventsTest do
   alias Game.NPC.State
 
   setup do
-    @room.clear_says()
-    @room.clear_emotes()
-
     start_and_clear_damage_types()
 
     %{key: "slashing", stat_modifier: :strength, boost_ratio: 20}

--- a/test/game/npc/events_test.exs
+++ b/test/game/npc/events_test.exs
@@ -3,8 +3,6 @@ defmodule Game.NPC.EventsTest do
 
   import Test.DamageTypesHelper
 
-  @room Test.Game.Room
-
   alias Data.Events.Actions.CommandsSay
   alias Data.Events.RoomHeard
   alias Data.Events.StateTicked
@@ -58,10 +56,7 @@ defmodule Game.NPC.EventsTest do
 
       state = %State{room_id: 1, npc: npc, target: nil}
 
-      @room._room()
-      |> Map.put(:npcs, [npc])
-      |> Map.put(:players, [%{id: 1, name: "Player"}])
-      |> @room.set_room()
+      start_room(%{npcs: [npc], players: [%{id: 1, name: "Player"}]})
 
       event = {"character/died", {:player, character}, :character, {:npc, npc}}
 

--- a/test/game/npc_test.exs
+++ b/test/game/npc_test.exs
@@ -1,19 +1,13 @@
 defmodule Game.NPCTest do
-  use Data.ModelCase
+  use ExVenture.NPCCase
 
   import Test.DamageTypesHelper
-
-  @room Test.Game.Room
 
   alias Game.NPC
   alias Game.NPC.State
   alias Game.Session.Registry
 
   setup do
-    @room.clear_notifies()
-    @room.clear_says()
-    @room.clear_leaves()
-
     start_and_clear_damage_types()
 
     insert_damage_type(%{
@@ -63,8 +57,8 @@ defmodule Game.NPCTest do
     {:noreply, state} = NPC.handle_cast({:apply_effects, [effect], {:player, %{id: 2, name: "Player"}}, "description"}, state)
     assert state.npc.stats.health_points == 0
 
-    assert [{1, {:npc, _}, :death}] = @room.get_leaves()
-    assert [{1, {"character/died", _, _, _}}] = @room.get_notifies()
+    assert_leave {1, {:npc, _}, :death}
+    assert_notify {"character/died", _, _, _}
 
     Registry.unregister()
   end

--- a/test/game/room/actions_test.exs
+++ b/test/game/room/actions_test.exs
@@ -81,7 +81,7 @@ defmodule Game.Room.ActionsTest do
 
     test "doesn't spawn again if already spawning", %{room: room, item: %{id: item_id}} do
       {:update, _state} = Room.Actions.maybe_respawn_items(%{room: %{room | items: []}, respawn: %{item_id => Timex.now}})
-      refute_receive {:respawn, ^item_id}
+      refute_receive {:respawn, ^item_id}, 50
     end
 
     test "respawns an item", %{room: room, item: %{id: item_id}} do

--- a/test/game/session/effects_test.exs
+++ b/test/game/session/effects_test.exs
@@ -67,7 +67,7 @@ defmodule Game.Session.EffectsTest do
       [] = state.continuous_effects
 
       effect_id = effect.id
-      refute_receive {:continuous_effect, ^effect_id}
+      refute_receive {:continuous_effect, ^effect_id}, 50
     end
 
     test "does nothing if effect is not found", %{state: state} do

--- a/test/game/session/effects_test.exs
+++ b/test/game/session/effects_test.exs
@@ -50,6 +50,8 @@ defmodule Game.Session.EffectsTest do
     end
 
     test "handles death", %{state: state, effect: effect, from: from} do
+      start_room(%{id: state.save.room_id})
+
       effect = %{effect | amount: 38}
       state = %{state | continuous_effects: [{from, effect}]}
 

--- a/test/game/session/effects_test.exs
+++ b/test/game/session/effects_test.exs
@@ -5,11 +5,7 @@ defmodule Game.Session.EffectsTest do
 
   alias Game.Session.Effects
 
-  @room Test.Game.Room
-
   setup do
-    @room.clear_update_characters()
-
     start_and_clear_damage_types()
 
     insert_damage_type(%{

--- a/test/game/session_test.exs
+++ b/test/game/session_test.exs
@@ -97,7 +97,7 @@ defmodule Game.SessionTest do
       assert stats.skill_points == 12
       assert stats.endurance_points == 10
 
-      refute_received {:"$gen_cast", {:echo, ~s(You regenerated some health and skill points.)}}
+      refute_received {:"$gen_cast", {:echo, ~s(You regenerated some health and skill points.)}}, 50
     end
 
     test "does not echo if config is off", %{state: state} do
@@ -113,7 +113,7 @@ defmodule Game.SessionTest do
       assert stats.skill_points == 11
       assert stats.endurance_points == 9
 
-      refute_receive {:"$gen_cast", {:echo, ~s(You regenerated some health and skill points.)}}
+      refute_receive {:"$gen_cast", {:echo, ~s(You regenerated some health and skill points.)}}, 50
     end
 
     test "does not regen, only increments count if not high enough", %{state: state} do
@@ -345,7 +345,7 @@ defmodule Game.SessionTest do
 
     assert state.save.stats.health_points == -5
 
-    refute_receive {:"$gen_cast", {:teleport, _}}
+    refute_receive {:"$gen_cast", {:teleport, _}}, 50
   after
     Session.Registry.unregister()
   end

--- a/test/game/session_test.exs
+++ b/test/game/session_test.exs
@@ -8,10 +8,7 @@ defmodule Game.SessionTest do
   alias Game.Session
   alias Game.Session.Process
 
-  @room Test.Game.Room
   @zone Test.Game.Zone
-
-  @basic_room %Game.Environment.State.Room{id: 1, name: "", description: "", players: [], shops: [], zone: %{id: 1, name: ""}}
 
   setup do
     user = base_user()
@@ -146,7 +143,8 @@ defmodule Game.SessionTest do
   test "processing a command that has continued commands", %{state: state} do
     user = create_user(%{name: "user", password: "password"})
 
-    @room.set_room(%{@basic_room | exits: [%Exit{has_door: false, direction: "north", start_id: 1, finish_id: 2}]})
+    start_simple_room(%{exits: [%Exit{has_door: false, direction: "north", start_id: 1, finish_id: 2}]})
+    start_room(%{id: 2})
 
     state = %{state | user: user,
       save: %{level: 1, room_id: 1, experience_points: 10, stats: %{base_stats() | endurance_points: 10}},
@@ -166,7 +164,8 @@ defmodule Game.SessionTest do
     character = create_character(user)
     character = Repo.preload(character, [:race, class: [:skills]])
 
-    @room.set_room(%{@basic_room | exits: [%Exit{has_door: false, direction: "north", start_id: 1, finish_id: 2}]})
+    start_simple_room(%{exits: [%Exit{has_door: false, direction: "north", start_id: 1, finish_id: 2}]})
+    start_room(%{id: 2})
 
     state = %{state | character: character,
       save: %{level: 1, room_id: 1, experience_points: 10, stats: %{base_stats() | endurance_points: 10}},
@@ -289,6 +288,8 @@ defmodule Game.SessionTest do
   test "applying effects - died", %{state: state} do
     Session.Registry.register(base_character(base_user()))
 
+    start_room(%{id: 1})
+
     effect = %{kind: "damage", type: "slashing", amount: 15}
     stats = %{base_stats() | health_points: 5, strength: 10}
     user = %{base_user() | id: 2, name: "user"}
@@ -297,8 +298,8 @@ defmodule Game.SessionTest do
 
     state = %{state | user: user, character: character, save: save}
     {:noreply, state} = Process.handle_cast({:apply_effects, [effect], {:npc, %{id: 1, name: "Bandit"}}, "description"}, state)
-    assert state.save.stats.health_points == -5
 
+    assert state.save.stats.health_points == -5
     assert_received {:"$gen_cast", {:echo, ~s(description\n10 slashing damage is dealt) <> _}}
     assert_notify {"character/died", _, _, _}
   after
@@ -308,7 +309,7 @@ defmodule Game.SessionTest do
   test "applying effects - died with zone graveyard", %{state: state} do
     Session.Registry.register(base_character(base_user()))
 
-    @room.set_room(@room._room())
+    start_room(%{})
     @zone.set_zone(Map.put(@zone._zone(), :graveyard_id, 2))
 
     effect = %{kind: "damage", type: "slashing", amount: 15}
@@ -330,7 +331,7 @@ defmodule Game.SessionTest do
   test "applying effects - died with no zone graveyard", %{state: state} do
     Session.Registry.register(base_character(base_user()))
 
-    @room.set_room(@room._room())
+    start_room(%{})
     @zone.set_zone(Map.put(@zone._zone(), :graveyard_id, nil))
     @zone.set_graveyard({:error, :no_graveyard})
 
@@ -423,13 +424,18 @@ defmodule Game.SessionTest do
     end
 
     test "teleports the character", %{state: state, character: character, room: room} do
+      start_room(%{id: room.id})
+
       {:noreply, state} = Process.handle_cast({:teleport, room.id}, %{state | character: character, save: character.save})
+
       assert state.save.room_id == room.id
     end
   end
 
   describe "resurrection" do
     test "sets health_points to 1 if < 0", %{state: state} do
+      start_room(%{id: 2})
+
       save = %{stats: %{base_stats() | health_points: -1}, experience_points: 10, room_id: 2}
       state = %{state | save: save}
 
@@ -440,6 +446,8 @@ defmodule Game.SessionTest do
     end
 
     test "leaves old room, enters new room", %{state: state} do
+      start_room(%{id: 2})
+
       save = %{stats: %{base_stats() | health_points: -1}, experience_points: 10, room_id: 1}
       state = %{state | save: save}
 

--- a/test/support/command_case.ex
+++ b/test/support/command_case.ex
@@ -1,5 +1,7 @@
 defmodule ExVenture.CommandCase do
-  defmacro __using__(_) do
+  use ExUnit.CaseTemplate
+
+  using do
     quote do
       use Data.ModelCase
 

--- a/test/support/networking.ex
+++ b/test/support/networking.ex
@@ -11,7 +11,7 @@ defmodule Test.Networking.Socket do
     """
     defmacro assert_socket_echo(messages) when is_list(messages) do
       quote do
-        assert_receive {:echo, _, recv_message}
+        assert_received {:echo, _, recv_message}
         Enum.map(unquote(messages), fn message ->
           assert Regex.match?(~r(#{message})i, recv_message)
         end)
@@ -20,14 +20,14 @@ defmodule Test.Networking.Socket do
 
     defmacro assert_socket_echo(message) do
       quote do
-        assert_receive {:echo, _, recv_message}
+        assert_received {:echo, _, recv_message}
         assert Regex.match?(~r(#{unquote(message)})i, recv_message)
       end
     end
 
     defmacro refute_socket_echo(message) do
       quote do
-        assert_receive {:echo, _, recv_message}
+        assert_received {:echo, _, recv_message}
         refute Regex.match?(~r(#{unquote(message)})i, recv_message)
       end
     end
@@ -40,7 +40,7 @@ defmodule Test.Networking.Socket do
 
     defmacro assert_socket_prompt(message) do
       quote do
-        assert_receive {:prompt, _, recv_message}
+        assert_received {:prompt, _, recv_message}
         assert Regex.match?(~r(#{unquote(message)})i, recv_message)
       end
     end
@@ -53,13 +53,13 @@ defmodule Test.Networking.Socket do
 
     defmacro assert_socket_gmcp(message) do
       quote do
-        assert_receive {:gmcp, _socket, unquote(message)}
+        assert_received {:gmcp, _socket, unquote(message)}
       end
     end
 
     defmacro assert_socket_disconnect() do
       quote do
-        assert_receive {:disconnect, _}
+        assert_received {:disconnect, _}
       end
     end
 

--- a/test/support/networking.ex
+++ b/test/support/networking.ex
@@ -34,7 +34,7 @@ defmodule Test.Networking.Socket do
 
     defmacro refute_socket_echo() do
       quote do
-        refute_receive {:echo, _, _}
+        refute_receive {:echo, _, _}, 50
       end
     end
 
@@ -47,7 +47,7 @@ defmodule Test.Networking.Socket do
 
     defmacro assert_socket_no_echo() do
       quote do
-        refute_receive {:echo, _, _}
+        refute_receive {:echo, _, _}, 50
       end
     end
 
@@ -65,7 +65,7 @@ defmodule Test.Networking.Socket do
 
     defmacro refute_socket_disconnect() do
       quote do
-        refute_receive {:disconnect, _}
+        refute_receive {:disconnect, _}, 50
       end
     end
   end

--- a/test/support/npc_case.ex
+++ b/test/support/npc_case.ex
@@ -1,10 +1,11 @@
-defmodule ExVenture.CommandCase do
+defmodule ExVenture.NPCCase do
   defmacro __using__(_) do
     quote do
       use Data.ModelCase
 
-      import Test.Networking.Socket.Helpers
       import Test.Game.Room.Helpers
+
+      alias Game.NPC.State
     end
   end
 end

--- a/test/support/npc_case.ex
+++ b/test/support/npc_case.ex
@@ -1,5 +1,7 @@
 defmodule ExVenture.NPCCase do
-  defmacro __using__(_) do
+  use ExUnit.CaseTemplate
+
+  using do
     quote do
       use Data.ModelCase
 

--- a/test/support/room.ex
+++ b/test/support/room.ex
@@ -191,10 +191,6 @@ defmodule Test.Game.Room do
       Room.set_room(Map.merge(basic_room, attributes))
     end
 
-    def start_overworld_room(cell) do
-      Room.set_room(cell)
-    end
-
     def put_pick_up_response(room, response) do
       Room.set_pick_up(room, response)
     end

--- a/test/support/room.ex
+++ b/test/support/room.ex
@@ -179,7 +179,7 @@ defmodule Test.Game.Room do
 
     defmacro refute_enter() do
       quote do
-        refute_receive {:enter, _}, 50
+        refute_received {:enter, _}
       end
     end
 
@@ -191,7 +191,7 @@ defmodule Test.Game.Room do
 
     defmacro refute_leave() do
       quote do
-        refute_receive {:leave, _}, 50
+        refute_received {:leave, _}
       end
     end
 
@@ -210,7 +210,7 @@ defmodule Test.Game.Room do
 
     defmacro refute_say() do
       quote do
-        refute_receive {:say, _}
+        refute_receive {:say, _}, 50
       end
     end
   end

--- a/test/support/session_case.ex
+++ b/test/support/session_case.ex
@@ -3,6 +3,7 @@ defmodule ExVenture.SessionCase do
     quote do
       use Data.ModelCase
 
+      import Test.Game.Room.Helpers
       import Test.Networking.Socket.Helpers
     end
   end


### PR DESCRIPTION
This turns the room test helper into sending messages to the test process, instead of using the agent to see what happened. Removing a global process (the agent.) A new fake room process is spun up instead for any requests that require a `call`, such as `look`ing.