### PR TITLE
Use default admin colors in UI

### DIFF
--- a/assets/play_react/js/GameContainer/MiddlePane/PlayerHud/ActionBar.jsx
+++ b/assets/play_react/js/GameContainer/MiddlePane/PlayerHud/ActionBar.jsx
@@ -10,11 +10,12 @@ const FlexColumn = styled.div`
 
 const ActionButton = styled.div`
   display: inline-block;
-  color: #444;
-  border: 1px solid #6177c8;
-  background: #879ade;
+  background: #1d4651;
   box-shadow: 0 2px 5px 0px #000000;
   border-radius: 5px;
+  border-left: 0px;
+  border-right: 0px;
+  border-bottom: 0px;
   cursor: pointer;
   vertical-align: middle;
   max-width: 35px;
@@ -30,6 +31,7 @@ const ActionBar = ({ dispatch, characterSkills }) => (
     {' '}
     {characterSkills.map(skill => (
       <ActionButton
+        className="panel"
         key={skill.key}
         onClick={() => {
           dispatch(send(skill.name.toLowerCase()));

--- a/assets/play_react/js/GameContainer/MiddlePane/PlayerHud/InputBar.jsx
+++ b/assets/play_react/js/GameContainer/MiddlePane/PlayerHud/InputBar.jsx
@@ -6,8 +6,8 @@ import { send } from '../../../redux/actions/actions.js';
 const Bar = styled.input`
   display: inline-block;
   color: #444;
-  border: 1px solid #6177c8;
-  background: #879ade;
+  border: 0px;
+  background: #1d4651;
   box-shadow: 0 2px 5px 0px #000000;
   border-radius: 5px;
   vertical-align: middle;
@@ -19,7 +19,6 @@ const Bar = styled.input`
 `;
 
 const InputBar = ({ dispatch }) => {
-  console.log('inputBar SEND', send);
   let state = {};
   const handleSubmit = e => {
     e.preventDefault();

--- a/assets/play_react/js/GameContainer/MiddlePane/PlayerHud/StatusBar.jsx
+++ b/assets/play_react/js/GameContainer/MiddlePane/PlayerHud/StatusBar.jsx
@@ -15,8 +15,8 @@ const BarContainer = styled.div`
   font-family: ${theme.font};
   flex: 1;
   display: inline-block;
-  border: 1px solid #6177c8;
-  background: #879ade;
+  border: 0px;
+  background: #1d4651;
   box-shadow: 0 2px 5px 0px #000000;
   border-radius: 5px;
   vertical-align: middle;

--- a/assets/play_react/js/GameContainer/MiddlePane/RoomInfo.jsx
+++ b/assets/play_react/js/GameContainer/MiddlePane/RoomInfo.jsx
@@ -45,16 +45,15 @@ const RoomInfo = ({ dispatch, className, roomInfo }) => {
         {players.map(player => (
           <VmlParser vmlString={player.status_line} />
         ))}
-        {'  '}
         {npcs.map(npc => (
           <VmlParser vmlString={npc.status_line} />
-        ))}{' '}
-        {'  '}
+        ))}
         {shops.map(shop => (
           <VmlParser vmlString={shop.name} />
         ))}
-        {'  '}
         {/* Items in the Room.Info GMCP module are not VML tagged so we need to manually color them here. */}
+        <br />
+        {items.length > 0 ? 'Items: ' : null}
         {items.map((item, idx, itemsArr) => (
           <ColoredSpan color={theme.vml.item} key={item.id}>
             {item.name}

--- a/assets/play_react/js/GameContainer/index.jsx
+++ b/assets/play_react/js/GameContainer/index.jsx
@@ -11,14 +11,12 @@ const FlexRow = styled.div`
   flex-direction: row;
   height: 800px;
   widht: 100%;
-  color: ${theme.text};
   font-family: ${theme.font};
 `;
 
 const LeftPaneContainer = styled.div`
   padding: 2em 2em 2em 2em;
   flex: 1;
-  background-color: ${theme.bgSecondary};
 `;
 
 const MiddlePaneContainer = styled.div`
@@ -26,13 +24,11 @@ const MiddlePaneContainer = styled.div`
   flex: 0 0 768px;
   flex-direction: column;
   height: 800px;
-  background-color: ${theme.bgPrimary};
 `;
 
 const RightPaneContainer = styled.div`
   padding: 2em 2em 2em 2em;
   flex: 1;
-  background-color: ${theme.bgSecondary};
 `;
 
 const GameContainer = props => {
@@ -41,7 +37,7 @@ const GameContainer = props => {
       <MediaQuery minWidth={768}>
         {matches => {
           return matches ? (
-            <LeftPaneContainer>
+            <LeftPaneContainer className="character-info">
               <LeftPane />
             </LeftPaneContainer>
           ) : null;
@@ -49,13 +45,13 @@ const GameContainer = props => {
       </MediaQuery>
 
       <MiddlePaneContainer>
-        <MiddlePane />
+        <MiddlePane className="body" />
       </MiddlePaneContainer>
 
       <MediaQuery minWidth={768}>
         {matches => {
           return matches ? (
-            <RightPaneContainer>
+            <RightPaneContainer className="room-info">
               <RightPane />
             </RightPaneContainer>
           ) : null;


### PR DESCRIPTION
1. Panels and vml text conforming to admin default colors
2. Restyled action bars and buttons

At some point i'll need to rethink the entire CSS infrastructure as some css is pulling from the 'theme.js'  file in the frontend and the rest is pulling from css from the server rendered colors.css file. Some css is hardcoded since they aren't vml tagged. 

These streamlining changes will need to take some coordination with backend so i'll revisit later. 