### PR TITLE
Fix #124 - use password instead of hash errors

### DIFF
--- a/lib/web/templates/registration/new.html.eex
+++ b/lib/web/templates/registration/new.html.eex
@@ -55,7 +55,7 @@
       <div class="form-group has-feedback mt-3">
         <%= label f, :password %>
         <%= text_input f, :password, type: "password", class: "form-control", placeholder: "Password" %>
-        <%= error_tag f, :password_hash %>
+        <%= error_tag f, :password %>
       </div>
 
       <div class="form-group has-feedback">

--- a/test/data/user_test.exs
+++ b/test/data/user_test.exs
@@ -32,4 +32,9 @@ defmodule Data.UserTest do
     changeset = %User{} |> User.changeset(%{name: "user name"})
     assert changeset.errors[:name]
   end
+
+  test "ensure password is not blank" do
+    changeset = User.changeset(%User{}, %{name: "user", password: ""})
+    assert !changeset.valid?
+  end
 end

--- a/test/data/user_test.exs
+++ b/test/data/user_test.exs
@@ -35,6 +35,6 @@ defmodule Data.UserTest do
 
   test "ensure password is not blank" do
     changeset = User.changeset(%User{}, %{name: "user", password: ""})
-    assert !changeset.valid?
+    refute changeset.valid?
   end
 end

--- a/test/data/user_test.exs
+++ b/test/data/user_test.exs
@@ -35,6 +35,6 @@ defmodule Data.UserTest do
 
   test "ensure password is not blank" do
     changeset = User.changeset(%User{}, %{name: "user", password: ""})
-    refute changeset.valid?
+    assert changeset.errors[:password]
   end
 end


### PR DESCRIPTION

Uses `error_tag(f, :password)` instead of `error_tag(f, :password_hash)` in new account template for displaying errors, and adds a test to ensure that blank passwords do invalidate a changeset