### PR TITLE
Avoid swap files / GTAGS in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,12 @@ deploy/hosts_*
 deploy/group_vars/*
 /ex_venture.tar.gz
 /tmp
+
+# Emacs / Vim swap files
+*~
+.#*
+
+# GTAGS
+GTAGS
+GPATH
+GRTAGS


### PR DESCRIPTION
Avoids various non-necessary files from Vim and Emacs from being accidentally imported into the repo.