### PR TITLE
Start a new PG notification process to listen to table row changes

### DIFF
--- a/lib/ex_venture/release_tasks.ex
+++ b/lib/ex_venture/release_tasks.ex
@@ -32,7 +32,7 @@ defmodule ExVenture.ReleaseTasks do
   def seed do
     startup()
 
-    Game.Config.start_link()
+    Game.Config.start_link([name: Game.Config])
 
     # Run the seed script if it exists
     seed_script = Path.join([priv_dir(:ex_venture), "repo", "seeds.exs"])

--- a/lib/game/caches.ex
+++ b/lib/game/caches.ex
@@ -6,8 +6,8 @@ defmodule Game.Caches do
   """
   use Supervisor
 
-  def start_link() do
-    Supervisor.start_link(__MODULE__, [], name: __MODULE__)
+  def start_link(opts) do
+    Supervisor.start_link(__MODULE__, [], opts)
   end
 
   def init(_) do

--- a/lib/game/channel.ex
+++ b/lib/game/channel.ex
@@ -27,9 +27,8 @@ defmodule Game.Channel do
   @doc """
   Start the GenServer process for managing channels
   """
-  @spec start_link() :: {:ok, pid()}
-  def start_link() do
-    GenServer.start_link(__MODULE__, [], name: __MODULE__)
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, [], opts)
   end
 
   #

--- a/lib/game/config.ex
+++ b/lib/game/config.ex
@@ -65,9 +65,18 @@ defmodule Game.Config do
     willpower: 10
   }
 
-  @doc false
-  def start_link() do
-    Agent.start_link(fn -> %{} end, name: __MODULE__)
+  def child_spec(opts) do
+    %{
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, [opts]},
+      type: :worker,
+      restart: :permanent,
+      shutdown: 500
+    }
+  end
+
+  def start_link(opts) do
+    Agent.start_link(fn -> %{} end, opts)
   end
 
   def color_config(), do: @color_config

--- a/lib/game/insight.ex
+++ b/lib/game/insight.ex
@@ -7,8 +7,8 @@ defmodule Game.Insight do
 
   alias Metrics.CommandInstrumenter
 
-  def start_link() do
-    GenServer.start_link(__MODULE__, [], name: __MODULE__)
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, [], opts)
   end
 
   #

--- a/lib/game/items.ex
+++ b/lib/game/items.ex
@@ -69,11 +69,7 @@ defmodule Game.Items do
   """
   @spec insert(Item.t()) :: :ok
   def insert(item) do
-    members = :pg2.get_members(@key)
-
-    Enum.map(members, fn member ->
-      GenServer.call(member, {:insert, item})
-    end)
+    GenServer.call(__MODULE__, {:insert, item})
   end
 
   @doc """
@@ -94,15 +90,10 @@ defmodule Game.Items do
   #
 
   def init(_) do
-    :ok = :pg2.create(@key)
-    :ok = :pg2.join(@key, self())
-
-    GenServer.cast(self(), :load_items)
-
-    {:ok, %{}}
+    {:ok, %{}, {:continue, :load_items}}
   end
 
-  def handle_cast(:load_items, state) do
+  def handle_continue(:load_items, state) do
     items =
       Item
       |> preload([:item_aspects])

--- a/lib/game/pg_notifications.ex
+++ b/lib/game/pg_notifications.ex
@@ -1,0 +1,82 @@
+defmodule Game.PGNotifications do
+  @moduledoc """
+  Subscriber to the PG pubsub for table changes
+
+  For the game caching layer
+  """
+
+  use GenServer
+
+  alias Data.Item
+  alias Game.Items
+
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, [], opts)
+  end
+
+  def init(_) do
+    {:ok, %{}, {:continue, :connect}}
+  end
+
+  def handle_continue(:connect, state) do
+    with {:ok, pid, ref} <- listen("row_changed") do
+      state =
+        state
+        |> Map.put(:pg_pid, pid)
+        |> Map.put(:pg_ref, ref)
+
+      {:noreply, state}
+    else
+      error ->
+        {:stop, error, state}
+    end
+  end
+
+  def handle_info({:notification, _pid, _ref, "row_changed", payload}, state) do
+    with {:ok, data} <- Jason.decode(payload) do
+      update_local_cache(data)
+
+      {:noreply, state}
+    else
+      error ->
+        {:stop, error, state}
+    end
+  end
+
+  defp update_local_cache(%{"table" => "items", "record" => item}) do
+    item
+    |> map_to_struct(Item)
+    |> Items.reload()
+  end
+
+  defp update_local_cache(_unknown), do: :ok
+
+  defp map_to_struct(map, schema) do
+    fields = Enum.map(schema.__schema__(:fields), &to_string/1)
+
+    map =
+      map
+      |> Map.take(fields)
+      |> Enum.into(%{}, fn {key, val} ->
+        {String.to_atom(key), val}
+      end)
+
+    struct(schema, map)
+  end
+
+  defp listen(event_name) do
+    opts =
+      Keyword.take(Application.get_env(:ex_venture, Data.Repo), [
+        :username,
+        :database,
+        :hostname,
+        :port,
+        :password
+      ])
+
+    with {:ok, pid} <- Postgrex.Notifications.start_link(opts),
+         {:ok, ref} <- Postgrex.Notifications.listen(pid, event_name) do
+      {:ok, pid, ref}
+    end
+  end
+end

--- a/lib/game/server.ex
+++ b/lib/game/server.ex
@@ -19,8 +19,8 @@ defmodule Game.Server do
   def tick_interval(), do: @tick_interval
 
   @doc false
-  def start_link() do
-    GenServer.start_link(__MODULE__, [], name: __MODULE__)
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, [], opts)
   end
 
   def started_at() do

--- a/lib/game/session/registry.ex
+++ b/lib/game/session/registry.ex
@@ -24,8 +24,8 @@ defmodule Game.Session.Registry do
   end
 
   @doc false
-  def start_link() do
-    GenServer.start_link(__MODULE__, [], name: __MODULE__)
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, [], opts)
   end
 
   @doc """

--- a/lib/game/session/supervisor.ex
+++ b/lib/game/session/supervisor.ex
@@ -8,8 +8,8 @@ defmodule Game.Session.Supervisor do
   alias Game.Session
 
   @doc false
-  def start_link do
-    DynamicSupervisor.start_link(__MODULE__, nil, name: __MODULE__)
+  def start_link(opts) do
+    DynamicSupervisor.start_link(__MODULE__, nil, opts)
   end
 
   @doc """

--- a/lib/game/supervisor.ex
+++ b/lib/game/supervisor.ex
@@ -12,6 +12,7 @@ defmodule Game.Supervisor do
 
   def init(_) do
     children = [
+      worker(Game.PGNotifications, [[name: Game.PGNotifications]]),
       worker(Game.Session.Registry, []),
       worker(Game.Config, []),
       supervisor(Game.Caches, []),

--- a/lib/game/supervisor.ex
+++ b/lib/game/supervisor.ex
@@ -4,6 +4,7 @@ defmodule Game.Supervisor do
 
   Loads the main server and all other supervisors required
   """
+
   use Supervisor
 
   def start_link() do
@@ -12,18 +13,18 @@ defmodule Game.Supervisor do
 
   def init(_) do
     children = [
-      worker(Game.PGNotifications, [[name: Game.PGNotifications]]),
-      worker(Game.Session.Registry, []),
-      worker(Game.Config, []),
-      supervisor(Game.Caches, []),
-      worker(Game.Server, []),
-      supervisor(Game.Session.Supervisor, []),
-      worker(Game.Channel, []),
-      supervisor(Game.World, []),
-      worker(Game.Insight, []),
-      worker(Game.Help.Agent, [[name: Game.Help.Agent]])
+      {Game.PGNotifications, [name: Game.PGNotifications]},
+      {Game.Session.Registry, [name: Game.Session.Registry]},
+      {Game.Config, [name: Game.Config]},
+      {Game.Caches, [name: Game.Caches]},
+      {Game.Server, [name: Game.Server]},
+      {Game.Session.Supervisor, [name: Game.Session.Supervisor]},
+      {Game.Channel, [name: Game.Channel]},
+      {Game.World, [name: Game.World]},
+      {Game.Insight, [name: Game.Insight]},
+      {Game.Help.Agent, [name: Game.Help.Agent]}
     ]
 
-    supervise(children, strategy: :one_for_one)
+    Supervisor.init(children, strategy: :one_for_one)
   end
 end

--- a/lib/game/world.ex
+++ b/lib/game/world.ex
@@ -9,8 +9,8 @@ defmodule Game.World do
 
   alias Game.Zone
 
-  def start_link() do
-    Supervisor.start_link(__MODULE__, [], name: __MODULE__)
+  def start_link(opts) do
+    Supervisor.start_link(__MODULE__, [], opts)
   end
 
   @doc """

--- a/lib/web/item.ex
+++ b/lib/web/item.ex
@@ -10,7 +10,6 @@ defmodule Web.Item do
   alias Data.Item
   alias Data.Stats
   alias Data.Repo
-  alias Game.Items
   alias Web.Filter
   alias Web.Pagination
 
@@ -116,16 +115,9 @@ defmodule Web.Item do
   """
   @spec create(params :: map) :: {:ok, Item.t()} | {:error, changeset :: map}
   def create(params) do
-    changeset = %Item{} |> Item.changeset(cast_params(params))
-
-    case changeset |> Repo.insert() do
-      {:ok, item} ->
-        Items.insert(item)
-        {:ok, item}
-
-      anything ->
-        anything
-    end
+    %Item{}
+    |> Item.changeset(cast_params(params))
+    |> Repo.insert()
   end
 
   @doc """
@@ -133,17 +125,10 @@ defmodule Web.Item do
   """
   @spec update(id :: integer, params :: map) :: {:ok, Item.t()} | {:error, changeset :: map}
   def update(id, params) do
-    item = id |> get()
-    changeset = item |> Item.changeset(cast_params(params))
-
-    case changeset |> Repo.update() do
-      {:ok, item} ->
-        Items.reload(item)
-        {:ok, item}
-
-      anything ->
-        anything
-    end
+    id
+    |> get()
+    |> Item.changeset(cast_params(params))
+    |> Repo.update()
   end
 
   @doc """

--- a/priv/repo/migrations/20190311160739_create_pg_row_change_notification.exs
+++ b/priv/repo/migrations/20190311160739_create_pg_row_change_notification.exs
@@ -1,0 +1,30 @@
+defmodule Data.Repo.Migrations.CreatePgRowChangeNotification do
+  use Ecto.Migration
+
+  def change do
+    execute("""
+    CREATE OR REPLACE FUNCTION notify_row_changes()
+    RETURNS trigger AS $$
+    BEGIN
+      PERFORM pg_notify(
+        'row_changed',
+        json_build_object(
+          'table', TG_TABLE_NAME,
+          'operation', TG_OP,
+          'record', row_to_json(NEW)
+        )::text
+      );
+      RETURN NEW;
+    END;
+    $$ LANGUAGE plpgsql;
+    """)
+
+    execute("""
+    CREATE TRIGGER items_changed
+    AFTER INSERT OR UPDATE
+    ON items
+    FOR EACH ROW
+    EXECUTE PROCEDURE notify_row_changes()
+    """)
+  end
+end

--- a/test/game/items_test.exs
+++ b/test/game/items_test.exs
@@ -41,12 +41,12 @@ defmodule Game.ItemsTest do
       Items.insert(%{id: 1, name: "Sword"})
       ensure_process_caught_up(Items)
 
-      [:ok] = Items.reload(%{id: 1, name: "Sword"})
+      :ok = Items.reload(%{id: 1, name: "Sword"})
       assert Items.item(1) == %{id: 1, name: "Sword"}
     end
 
     test "push a new item in" do
-      [:ok] = Items.insert(%{id: 10, name: "Sword"})
+      :ok = Items.insert(%{id: 10, name: "Sword"})
       ensure_process_caught_up(Items)
       assert Items.item(10) == %{id: 10, name: "Sword"}
     end

--- a/test/web/controller/admin/item_controller_test.exs
+++ b/test/web/controller/admin/item_controller_test.exs
@@ -1,8 +1,7 @@
 defmodule Web.Admin.ItemControllerTest do
   use Web.AuthConnCase
-  import Test.ItemsHelper
 
-  alias Game.Items
+  import Test.ItemsHelper
 
   setup do
     start_and_clear_items()
@@ -27,8 +26,5 @@ defmodule Web.Admin.ItemControllerTest do
   test "update an item", %{conn: conn, item: item} do
     conn = put conn, item_path(conn, :update, item.id), item: %{name: "Short Sword", keywords: "sword, short"}
     assert redirected_to(conn) == item_path(conn, :show, item.id)
-
-    assert Items.item(item.id).name == "Short Sword"
-    assert Items.item(item.id).keywords == ["sword", "short"]
   end
 end


### PR DESCRIPTION
- First up with items
- Removes the pg2 group for spanning changes across the cluster
- The new process will notify the local node it's on of any changes to
  item state

Using ideas from this blog post https://medium.com/@toddresudek/caching-in-an-elixir-phoenix-app-a499cdf91046